### PR TITLE
Rename docker::image class parameter "tag" to "image_tag"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For that reason this define turns off the default 5 minute timeout for exec.
 Takes an optional parameter for installing image tags that is the equivalent to running `docker pull -t="precise" ubuntu`:  
 
     docker::image { 'ubuntu':
-      tag => 'precise'
+      image_tag => 'precise'
     }
 
 Note: images will only install if an image of that name does not already exist.  
@@ -40,7 +40,7 @@ You can also remove images you no longer need with:
 
     docker::image { 'ubuntu':
       ensure  => 'absent',
-      tag     => 'precise'
+      image_tag     => 'precise'
     }
 
 ### Containers

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -1,16 +1,16 @@
 define docker::image(
   $ensure = 'present',
   $image  = $title,
-  $tag    = undef
+  $image_tag    = undef
 ) {
 
   validate_re($ensure, '^(present|absent)$')
   validate_re($image, '^[\S]*$')
 
-    if $tag {
-      $image_install = "docker pull -t=\"${tag}\" ${image}"
-      $image_remove  = "docker rmi ${image}:${tag}"
-      $image_find    = "docker images | grep ^${image} | awk '{ print \$2 }' | grep ${tag}"
+    if $image_tag {
+      $image_install = "docker pull -t=\"${image_tag}\" ${image}"
+      $image_remove  = "docker rmi ${image}:${image_tag}"
+      $image_find    = "docker images | grep ^${image} | awk '{ print \$2 }' | grep ${image_tag}"
     } else {
       $image_install = "docker pull ${image}"
       $image_remove  = "docker rmi ${image}"

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -9,8 +9,8 @@ describe 'docker::image', :type => :define do
     it { should contain_exec('docker rmi base') }
   end
 
-  context 'with ensure => absent and tag => precise' do
-    let(:params) { { 'ensure' => 'absent', 'tag' => 'precise' } }
+  context 'with ensure => absent and image_tag => precise' do
+    let(:params) { { 'ensure' => 'absent', 'image_tag' => 'precise' } }
     it { should contain_exec('docker rmi base:precise') }
   end
 
@@ -19,8 +19,8 @@ describe 'docker::image', :type => :define do
     it { should contain_exec('docker pull base') }
   end
 
-  context 'with ensure => present and tag => precise' do
-    let(:params) { { 'ensure' => 'present', 'tag' => 'precise' } }
+  context 'with ensure => present and image_tag => precise' do
+    let(:params) { { 'ensure' => 'present', 'image_tag' => 'precise' } }
     it { should contain_exec('docker pull -t="precise" base') }
   end
 


### PR DESCRIPTION
Puppet was giving me runtime warnings because "tag" is a reserved metaparameter name (http://docs.puppetlabs.com/references/latest/metaparameter.html#tag).  

I renamed "tag" to "image_tag", updated the appropriate test, and updated README.md.
