### PR TITLE
Install of raring kernel on precise

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,9 +26,18 @@ class docker::install {
     include_src       => false,
   }
 
-  # determine the package name for 'linux-image-extra-$(uname -r)' based on the
-  # $::kernelrelease fact
-  $kernelpackage = "linux-image-extra-${::kernelrelease}"
+  case $::operatingsystemrelease {
+    # On Ubuntu 12.04 (precise) install the backported 13.04 (raring) kernel
+    '12.04': { $kernelpackage = [
+                                  'linux-image-generic-lts-raring',
+                                  'linux-headers-generic-lts-raring'
+                                ]
+    }
+    # determine the package name for 'linux-image-extra-$(uname -r)' based on
+    # the $::kernelrelease fact
+    default: { $kernelpackage = "linux-image-extra-${::kernelrelease}" }
+  }
+
 
   package { $kernelpackage:
     ensure => present,


### PR DESCRIPTION
Docker works best on the 3.8 kernel.
Precise comes with a 3.2 kernel, so we need to upgrade it.

Stolen from http://docs.docker.io/en/latest/installation/ubuntulinux/

---

I am not sure if this is the approach that you would wish to take or not, however it fixed the following issue I ran into. 
On my 12.04 installation using the raring kernel, the module was trying to install the headers of the raring kernel however it couldn't find them.

``` sh
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install linux-image-extra-3.8.0-31-generic' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package linux-image-extra-3.8.0-31-generic
E: Couldn't find any package by regex 'linux-image-extra-3.8.0-31-generic'

Error: /Stage[main]/Docker::Install/Package[linux-image-extra-3.8.0-31-generic]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install linux-image-extra-3.8.0-31-generic' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package linux-image-extra-3.8.0-31-generic
E: Couldn't find any package by regex 'linux-image-extra-3.8.0-31-generic'
```

:) Thanks for the module .

Danny
