### PR TITLE
Make the apt::source optional, for folks who run their own apt mirrors.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,15 +18,20 @@
 #   The unix socket to bind to. Defaults to
 #   unix:///var/run/docker.sock.
 #
+# [*use_upstream_apt_source*]
+#   Whether or not to use the upstream apt source.
+#   If you run your own package mirror, you may set this
+#   to false.
 # [*manage_kernel*]
 #   Attempt to install the correct Kernel required by docker
 #   Defaults to true
 #
 class docker(
-  $version       = $docker::params::version,
-  $tcp_bind      = $docker::params::tcp_bind,
-  $socket_bind   = $docker::params::socket_bind,
-  $manage_kernel = true
+  $version                 = $docker::params::version,
+  $tcp_bind                = $docker::params::tcp_bind,
+  $socket_bind             = $docker::params::socket_bind,
+  $use_upstream_apt_source = $docker::params::use_upstream_apt_source,
+  $manage_kernel           = true
 ) inherits docker::params {
 
   validate_string($version)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,20 +5,25 @@
 # only on Debian based distributions.
 #
 class docker::install {
-  include apt
   validate_string($docker::version)
   validate_re($::osfamily, '^Debian$', 'This module uses the docker apt repo and only works on Debian systems that support it.')
   validate_string($::kernelrelease)
+  validate_bool($docker::use_upstream_apt_source)
 
-  apt::source { 'docker':
-    location          => 'https://get.docker.io/ubuntu',
-    release           => 'docker',
-    repos             => 'main',
-    required_packages => 'debian-keyring debian-archive-keyring',
-    key               => 'A88D21E9',
-    key_source        => 'http://get.docker.io/gpg',
-    pin               => '10',
-    include_src       => false,
+  if ($docker::use_upstream_apt_source) {
+    include apt
+    apt::source { 'docker':
+      location          => 'https://get.docker.io/ubuntu',
+      release           => 'docker',
+      repos             => 'main',
+      required_packages => 'debian-keyring debian-archive-keyring',
+      key               => 'A88D21E9',
+      key_source        => 'http://get.docker.io/gpg',
+      pin               => '10',
+      include_src       => false,
+    }
+
+    Apt::Source['docker'] -> Package['lxc-docker']
   }
 
   case $::operatingsystemrelease {
@@ -42,7 +47,5 @@ class docker::install {
 
   package { 'lxc-docker':
     ensure  => $docker::version,
-    require => Apt::Source['docker'],
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 class docker::params {
-  $version     = present
-  $tcp_bind    = undef
-  $socket_bind = 'unix:///var/run/docker.sock'
+  $version                 = present
+  $tcp_bind                = undef
+  $socket_bind             = 'unix:///var/run/docker.sock'
+  $use_upstream_apt_source = true
 }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -15,7 +15,7 @@ describe 'docker', :type => :class do
   context 'with no parameters' do
     it { should include_class('apt') }
     it { should contain_package('lxc-docker').with_ensure('present') }
-    it { should contain_package('lxc-docker').with_require('Apt::Source[docker]') }
+    it { should contain_apt__source('docker') }
     it { should contain_package('linux-image-extra-3.8.0-29-generic') }
   end
 
@@ -31,6 +31,13 @@ describe 'docker', :type => :class do
         should contain_package('lxc-docker')
       }.to raise_error(Puppet::Error, /^This module uses the docker apt repo/)
     end
+  end
+
+  context 'with no upstream apt source' do
+    let(:params) { {'use_upstream_apt_source' => false } }
+    it { should_not contain_apt__source('docker') }
+    it { should contain_package('lxc-docker') }
+    it { should contain_package('linux-image-extra-3.8.0-29-generic') }
   end
 
   context 'when not managing the kernel' do


### PR DESCRIPTION
I have an apt mirror internally that I'd rather manage on my own. This patch allows me to do that.
