### PR TITLE
Make docker service state configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class docker(
   $tcp_bind                = $docker::params::tcp_bind,
   $socket_bind             = $docker::params::socket_bind,
   $use_upstream_apt_source = $docker::params::use_upstream_apt_source,
+  $service_state           = $docker::params::service_state,
   $manage_kernel           = true
 ) inherits docker::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,4 +3,5 @@ class docker::params {
   $tcp_bind                = undef
   $socket_bind             = 'unix:///var/run/docker.sock'
   $use_upstream_apt_source = true
+  $service_state           = running
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,9 +1,10 @@
 class docker::service (
-  $tcp_bind    = $docker::tcp_bind,
-  $socket_bind = $docker::socket_bind,
+  $tcp_bind             = $docker::tcp_bind,
+  $socket_bind          = $docker::socket_bind,
+  $service_state        = $docker::service_state,
 ){
   service { 'docker':
-    ensure     => running,
+    ensure     => $service_state,
     enable     => true,
     hasstatus  => true,
     hasrestart => true,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -56,4 +56,9 @@ describe 'docker', :type => :class do
     it { should contain_package('linux-headers-generic-lts-raring') }
   end
 
+  context 'with service_state set to stopped' do
+    let(:params) { {'service_state' => 'stopped'} }
+
+    it { should contain_service('docker').with_ensure('stopped') }
+  end
 end


### PR DESCRIPTION
We are building AMIs on EC2 via a chroot and don't want the process to be running.
