### PR TITLE
Allow the apt source location to be customised

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,9 @@
 #   Whether or not to use the upstream apt source.
 #   If you run your own package mirror, you may set this
 #   to false.
+# [*apt_source_location*]
+#   If you're using an upstream apt source, what is it's
+#   location. Defaults to https://get.docker.io/ubuntu
 # [*manage_kernel*]
 #   Attempt to install the correct Kernel required by docker
 #   Defaults to true
@@ -32,6 +35,7 @@ class docker(
   $tcp_bind                = $docker::params::tcp_bind,
   $socket_bind             = $docker::params::socket_bind,
   $use_upstream_apt_source = $docker::params::use_upstream_apt_source,
+  $apt_source_location     = $docker::params::apt_source_location,
   $service_state           = $docker::params::service_state,
   $root_dir                = $docker::params::root_dir,
   $manage_kernel           = true

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,7 @@ class docker::install {
   if ($docker::use_upstream_apt_source) {
     include apt
     apt::source { 'docker':
-      location          => 'https://get.docker.io/ubuntu',
+      location          => $docker::apt_source_location,
       release           => 'docker',
       repos             => 'main',
       required_packages => 'debian-keyring debian-archive-keyring',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,4 +10,5 @@ class docker::params {
   $use_upstream_apt_source = true
   $service_state           = running
   $root_dir                = undef
+  $apt_source_location     = 'https://get.docker.io/ubuntu'
 }


### PR DESCRIPTION
This is primarily so that I can use the http repository, and thus apt_cacher_ng
