### PR TITLE
Stop using daemon mode in upstart scripts.

### DIFF
--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -4,11 +4,9 @@ author "Gareth Rushgrove"
 start on (started docker)
 stop on runlevel [!2345]
 
-expect daemon
-
 setuid root
 
 respawn
 respawn limit 5 20
 
-exec docker run -d -u '<%= @username %>' -h '<%= @hostname %>'<% if @dns %><% @dns_array.each do |address| %> -dns <%= address %><% end %><% end %><% if @env %><% @env_array.each do |env| %> -e <%= env %><% end %><% end %><% if @ports %><% @ports_array.each do |port| %> -p <%= port %><% end %><% end %><% if @volumes %><% @volumes_array.each do |volume| %> -v <%= volume %><% end %><% end %><% if @volumes_from %> -volumes-from <%= @volumes_from %><% end %> -m <%= @memory_limit %> <% if @links %><%= @links_array.map {|link| "-link #{link}" }.join(' ') %> <% end %><% if @use_name %>-name <%= @name %><% end %> <%= @image %> <% if @command %><%= @command %><% end %>
+exec docker run -u '<%= @username %>' -h '<%= @hostname %>'<% if @dns %><% @dns_array.each do |address| %> -dns <%= address %><% end %><% end %><% if @env %><% @env_array.each do |env| %> -e <%= env %><% end %><% end %><% if @ports %><% @ports_array.each do |port| %> -p <%= port %><% end %><% end %><% if @volumes %><% @volumes_array.each do |volume| %> -v <%= volume %><% end %><% end %><% if @volumes_from %> -volumes-from <%= @volumes_from %><% end %> -m <%= @memory_limit %> <% if @links %><%= @links_array.map {|link| "-link #{link}" }.join(' ') %> <% end %><% if @use_name %>-name <%= @name %><% end %> <%= @image %> <% if @command %><%= @command %><% end %>


### PR DESCRIPTION
In daemon mode then upstart never detects if the container craps out / exits, and therefore never respawns correctly (at least in the upstart version in precise)..

I'd at least like to run containers not as a daemon - let me know if you feel strongly about this, as I'm happy to supply an alternate patch allowing both behaviors if there are cases where daemon mode is a good thing that I'm not seeing ;)
