### PR TITLE
allow to suppress epel on red hat distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ class { 'docker':
 }
 ```
 
+If you want to configure your package sources independently,
+inform this module to not auto-include upstream sources:
+
+```puppet
+class { 'docker':
+  use_upstream_package_source => false,
+}
+```
+
 By default the docker daemon will bind to a unix socket at
 /var/run/docker.sock. This can be changed, as well as binding to a tcp
 socket if required.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,8 +51,10 @@ class docker::install {
       $dockerbasepkg = 'docker-io'
       $manage_kernel = false
 
-      include 'epel'
-      Class['epel'] -> Package[$dockerbasepkg]
+      if ($docker::use_upstream_package_source) {
+        include 'epel'
+        Class['epel'] -> Package[$dockerbasepkg]
+      }
     }
   }
 

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -45,7 +45,16 @@ describe 'docker', :type => :class do
       :osfamily => 'RedHat',
       :operatingsystemrelease => '6.5'
     } }
-    it { should contain_class('epel') }
+
+    context 'by default' do
+      it { should contain_class('epel') }
+    end
+
+    context 'with no upstream package source' do
+      let(:params) { {'use_upstream_package_source' => false } }
+      it { should_not contain_class('epel') }
+    end
+
     it { should_not contain_apt__source('docker') }
     it { should contain_package('docker').with_name('docker-io').with_ensure('present') }
     it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
@@ -66,6 +75,7 @@ describe 'docker', :type => :class do
   context 'with no upstream package source' do
     let(:params) { {'use_upstream_package_source' => false } }
     it { should_not contain_apt__source('docker') }
+    it { should_not contain_class('epel') }
     it { should contain_package('docker') }
     it { should contain_package('linux-image-extra-3.8.0-29-generic') }
   end


### PR DESCRIPTION
The `use_upstream_package_source` parameter already allows
apt users to suppress upstream repos. After this commit,
the param also applies to red hat and centos users.

New unit tests:

```
docker
  if running on a RedHat based distro
    by default
      should contain Class[epel]
    with no upstream package source
      should not contain Class[epel]
  with no upstream package source
    should not contain Class[epel]
```
