### PR TITLE
Use upstart only on Ubuntu based distros

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -43,6 +43,11 @@ define docker::run(
     'Debian': {
       $initscript = "/etc/init/docker-${title}.conf"
 
+      $provider = $::operatingsystem ? {
+        'Ubuntu' => 'upstart',
+        default  => undef,
+      }
+
       file { $initscript:
         ensure  => present,
         content => template('docker/etc/init/docker-run.conf.erb')
@@ -53,7 +58,7 @@ define docker::run(
         enable     => true,
         hasstatus  => true,
         hasrestart => true,
-        provider   => upstart;
+        provider   => $provider,
       }
     }
     'RedHat': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,12 +25,18 @@ class docker::service (
 ){
   case $::osfamily {
     'Debian': {
+
+      $provider = $::operatingsystem ? {
+        'Ubuntu' => 'upstart',
+        default  => undef,
+      }
+
       service { 'docker':
         ensure     => $service_state,
         enable     => $service_enable,
         hasstatus  => true,
         hasrestart => true,
-        provider   => upstart,
+        provider   => $provider,
       }
 
       file { '/etc/init/docker.conf':

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'docker', :type => :class do
   let(:facts) { {
     :osfamily        => 'Debian',
+    :operatingsystem => 'Ubuntu',
     :lsbdistid       => 'debian',
     :lsbdistcodename => 'maverick',
     :kernelrelease   => '3.8.0-29-generic'
@@ -14,6 +15,21 @@ describe 'docker', :type => :class do
   it { should contain_class('docker::service').that_subscribes_to('docker::config') }
   it { should contain_class('docker::config') }
   it { should contain_service('docker').with_provider('upstart') }
+
+  context 'if running on Debian distro' do
+    let(:facts) { {
+      :osfamily        => 'Debian',
+      :operatingsystem => 'Debian',
+      :lsbdistid       => 'debian',
+      :lsbdistcodename => 'wheezy',
+      :kernelrelease   => '3.12-1-amd64'
+    } }
+    it { should contain_service('docker').without_provider }
+    it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
+    it { should_not contain_package('linux-image-generic-lts-raring') }
+    it { should_not contain_package('linux-headers-generic-lts-raring') }
+    it { should contain_package('apt-transport-https').that_comes_before('Package[docker]') }
+  end
 
   context 'with no parameters' do
     it { should contain_class('apt') }


### PR DESCRIPTION
Hi Gareth, 

_upstart_ is not Debian's defaut provider, so `service` fails as it was hardcoded. This patch sets `provider` only when `$::operatingsystem => Ubuntu` and leaves it undef on other Debian derived distros.
