### PR TITLE
Create socket_group option, which gets passed in as the -G option.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,10 @@
 #   Custom dns server address
 #   Defaults to undefined
 #
+# [*socket_group*]
+#   Group ownership of the unix control socket.
+#   Defaults to undefined
+#
 # [*extra_parameters*]
 #   Any extra parameters that should be passed to the docker daemon.
 #   Defaults to undefined
@@ -66,6 +70,7 @@ class docker(
   $root_dir                    = $docker::params::root_dir,
   $manage_kernel               = true,
   $dns                         = $docker::params::dns,
+  $socket_group                = $docker::params::socket_group,
   $extra_parameters            = undef,
 ) inherits docker::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class docker::params {
   $ensure                       = present
   $tcp_bind                     = undef
   $socket_bind                  = 'unix:///var/run/docker.sock'
+  $socket_group                 = undef
   $use_upstream_package_source  = true
   $service_state                = running
   $service_enable               = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,6 +9,9 @@
 # [*socket_bind*]
 #   Which local unix socket to bind the docker service to.
 #
+# [*socket_group*]
+#   Which local unix socket to bind the docker service to.
+#
 # [*root_dir*]
 #   Specify a non-standard root directory for docker.
 #
@@ -18,6 +21,7 @@
 class docker::service (
   $tcp_bind             = $docker::tcp_bind,
   $socket_bind          = $docker::socket_bind,
+  $socket_group         = $docker::socket_group,
   $service_state        = $docker::service_state,
   $service_enable       = $docker::service_enable,
   $root_dir             = $docker::root_dir,

--- a/templates/etc/init/docker.conf.erb
+++ b/templates/etc/init/docker.conf.erb
@@ -6,6 +6,6 @@ stop on runlevel [!2345]
 respawn
 
 script
-  /usr/bin/docker -d <% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @dns %> -dns <%= @dns %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>
+  /usr/bin/docker -d <% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @dns %> -dns <%= @dns %><% end %><% if @socket_group %> -G <%= @socket_group %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>
 end script
 

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -1,1 +1,1 @@
-other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>"
+other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %><% if @socket_group %> -G <%= @socket_group %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>"


### PR DESCRIPTION
https://github.com/dotcloud/docker/pull/3612 added a `-G` option to docker that allows the user to control what group owns `/var/run/docker.sock`. This patch makes it possible to specify this parameter using `socket_group =>`

I'll have another similar pull request soon, so I'm considering refactoring the way parameters get constructed - it might make sense to pull the logic out into something that can be shared by both the RedHat and Debian templates.
