### PR TITLE
upstart: use exec here so upstart can monitor the process and not just a shell

### DIFF
--- a/templates/etc/init/docker.conf.erb
+++ b/templates/etc/init/docker.conf.erb
@@ -6,6 +6,6 @@ stop on runlevel [!2345]
 respawn
 
 script
-  <% if @proxy %>http_proxy=<%= @proxy %> https_proxy=<%= @proxy %> <% end %><% if @no_proxy %>no_proxy=<%= @no_proxy %> <% end %>/usr/bin/docker -d <% if @root_dir %>-g <%= @root_dir %> <% end %><% if @execdriver %>-e <%= @execdriver %> <% end %><% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @dns %> -dns <%= @dns %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>
+  exec <% if @proxy %>http_proxy=<%= @proxy %> https_proxy=<%= @proxy %> <% end %><% if @no_proxy %>no_proxy=<%= @no_proxy %> <% end %>/usr/bin/docker -d <% if @root_dir %>-g <%= @root_dir %> <% end %><% if @execdriver %>-e <%= @execdriver %> <% end %><% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @dns %> -dns <%= @dns %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>
 end script
 


### PR DESCRIPTION
This is in line with what I just opened for dotcloud/docker - https://github.com/dotcloud/docker/pull/4879

In short, upstart scripts should exec what they launch.  Otherwise, they monitor a shell instead of the intended process.  Here is an example of how things look with the script as it is:

```
$ sudo start docker
docker start/running, process 19992
$ ps aux | grep 19992
root     19992  0.0  0.0   4404   608 ?        Ss   10:31   0:00 /bin/sh -e -c /usr/bin/docker -d  -H unix:///var/run/docker.sock  -b=lxcbr0 -icc=false -r=false /bin/sh

$ ps aux | grep docker
root     19992  0.0  0.0   4404   608 ?        Ss   10:31   0:00 /bin/sh -e -c /usr/bin/docker -d  -H unix:///var/run/docker.sock  -b=lxcbr0 -icc=false -r=false /bin/sh
root     19993  1.0  0.1 207452  6476 ?        Sl   10:31   0:00 /usr/bin/docker -d -H unix:///var/run/docker.sock -b=lxcbr0 -icc=false -r=false
```

In the above example, we see that upstart is actually managing the spawning shell and not docker itself.  By using this branch, things behave properly:

```
$ sudo start docker
docker start/running, process 20613
$ ps aux | grep 20613
root     20613  3.6  0.1 207452  6408 ?        Ssl  10:33   0:00 /usr/bin/docker -d -H unix:///var/run/docker.sock -b=lxcbr0 -icc=false -r=false
```

Having upstart monitor the shells isn't the worst thing in the world, but it can lead to some sticky situations.  The important thing is that we're monitoring the process itself.
