### PR TITLE
Fix ordering for service{} declarations in docker::run

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -61,7 +61,7 @@ define docker::run(
         hasstatus  => true,
         hasrestart => true,
         provider   => $provider,
-        require    => Package['docker'],
+        require    => Class['docker'],
       }
     }
     'RedHat': {
@@ -76,7 +76,7 @@ define docker::run(
       service { "docker-${title}":
         ensure  => $running,
         enable  => true,
-        require => Package['docker'],
+        require => Class['docker'],
       }
     }
     default: {


### PR DESCRIPTION
Without this, it's possible for Puppet to try to run the service before Docker is installed, which will fail.
