### PR TITLE
properly detect already running instances

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -35,7 +35,7 @@ start() {
     if [ -f $cidfile ]; then
         cid="$(cat $cidfile)"
         if [ -n $cid ]; then
-            docker ps|grep $cid
+            docker ps --no-trunc=true|grep $cid
             retval=$?
             if [ $retval -eq 0 ]; then
                 failure


### PR DESCRIPTION
docker ps|grep $cid .. fails due to grepping the non-truncated CID against 'docker ps' which truncates by default. 

Without this, calling: /etc/init.d/docker-[container] start while the container is already running, causes another instance of the container to start.
