### PR TITLE
avoid ugly grep error if cidfile exists but is empty

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -34,7 +34,7 @@ start() {
 
     if [ -f $cidfile ]; then
         cid="$(cat $cidfile)"
-        if [ -n $cid ]; then
+        if [ -n "$cid" ]; then
             docker ps --no-trunc=true|grep $cid
             retval=$?
             if [ $retval -eq 0 ]; then


### PR DESCRIPTION
On Docker 0.9 (maybe higher versions as well) a cidfile will be created without cid, if the requested image is not found in the registry (404). I presume this is an upstream bug, but the proposed fix benefits the general behaviour of this puppet module.

The init script will not detect the above situation properly because of this behaviour:

```
[root@mag-lab06 ~]# if [ -n $this_var_does_not_exist ]; then echo success; fi
success
[root@mag-lab06 ~]# if [ -n "$this_var_does_not_exist" ]; then echo success; fi
[root@mag-lab06 ~]# 
```

Quotes are necessary to get the intended behaviour, otherwise empty cidfiles do undetected and grep misses it's required argument resulting in an ugly error.
