### PR TITLE
Fixes typo in SysVinit template

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -49,7 +49,7 @@ start() {
     fi
 
     printf "Starting $prog:\t"
-    $docker run -cidfile=$cidfile -d=true \
+    $docker run --cidfile=$cidfile -d=true \
         <% if @username %>-u '<%= @username %>' <% end %> \
         <% if @hostname %>-h '<%= @hostname %>'<% end %> \
         <% if @disable_network %>-n false<% end %> \


### PR DESCRIPTION
it's --cidfile, not -cidfile. docker complains about it when running a
container.
