### PR TITLE
Sysvinit fixes

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -7,7 +7,7 @@
 #
 #    Daemon for <%= @title %>
 #
-# chkconfig: 2345 97 97
+# chkconfig: 2345 97 15
 # description: Docker container for <%= @title %>
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
This fixes some issues on SysVinit systems. Includes:
- Fix for LSB init: the container should stop before the Docker daemon and the system's network
- Fix for chkconfig: lowered stop priority to 15 (was 97) so that the container is stopped early, but especially before the Docker daemon stops.
