### PR TITLE
Allow upstream apt source pin priority to be changed, or eliminated

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,14 @@
 #   Won't install or define the docker package, useful if you want to use your own package
 #   Defaults to true
 #
+# [*apt_source_pin_level*]
+#   What level to pin our source package repository to; this only is relevent
+#   if you're on an apt-based system (Debian, Ubuntu, etc) and
+#   $use_upstream_package_source is set to true.  Set this to false to disable
+#   pinning, and undef to ensure the apt preferences file apt::source uses to
+#   define pins is removed.
+#   Defaults to 10
+#
 # [*package_name*]
 #   Specify custom package name
 #   Default is set on a per system basis in docker::params
@@ -86,6 +94,7 @@ class docker(
   $tcp_bind                    = $docker::params::tcp_bind,
   $socket_bind                 = $docker::params::socket_bind,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
+  $apt_source_pin_level        = $docker::params::apt_source_pin_level,
   $package_source_location     = $docker::params::package_source_location,
   $service_state               = $docker::params::service_state,
   $service_enable              = $docker::params::service_enable,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class docker(
   $tcp_bind                    = $docker::params::tcp_bind,
   $socket_bind                 = $docker::params::socket_bind,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
-  $apt_source_pin_level        = $docker::params::apt_source_pin_level,
+  $apt_source_pin_level        = 10,
   $package_source_location     = $docker::params::package_source_location,
   $service_state               = $docker::params::service_state,
   $service_enable              = $docker::params::service_enable,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,20 @@
 #   If you run your own package mirror, you may set this
 #   to false.
 #
+# [*pin_upstream_package_source*]
+#   Pin upstream package source; this option currently only has any effect on
+#   apt-based distributions.  Set to false to remove pinning on the upstream
+#   package repository.  See also "apt_source_pin_level".
+#   Defaults to true
+#
+# [*apt_source_pin_level*]
+#   What level to pin our source package repository to; this only is relevent
+#   if you're on an apt-based system (Debian, Ubuntu, etc) and
+#   $use_upstream_package_source is set to true.  Set this to false to disable
+#   pinning, and undef to ensure the apt preferences file apt::source uses to
+#   define pins is removed.
+#   Defaults to 10
+#
 # [*package_source_location*]
 #   If you're using an upstream package source, what is it's
 #   location. Defaults to https://get.docker.io/ubuntu on Debian
@@ -67,14 +81,6 @@
 # [*manage_package*]
 #   Won't install or define the docker package, useful if you want to use your own package
 #   Defaults to true
-#
-# [*apt_source_pin_level*]
-#   What level to pin our source package repository to; this only is relevent
-#   if you're on an apt-based system (Debian, Ubuntu, etc) and
-#   $use_upstream_package_source is set to true.  Set this to false to disable
-#   pinning, and undef to ensure the apt preferences file apt::source uses to
-#   define pins is removed.
-#   Defaults to 10
 #
 # [*package_name*]
 #   Specify custom package name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,7 @@ class docker(
   $tcp_bind                    = $docker::params::tcp_bind,
   $socket_bind                 = $docker::params::socket_bind,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
+  $pin_upstream_package_source = true,
   $apt_source_pin_level        = 10,
   $package_source_location     = $docker::params::package_source_location,
   $service_state               = $docker::params::service_state,
@@ -118,6 +119,7 @@ class docker(
   validate_re($::osfamily, '^(Debian|RedHat)$', 'This module only works on Debian and Red Hat based systems.')
   validate_bool($manage_kernel)
   validate_bool($manage_package)
+  validate_bool($pin_upstream_package_source)
 
   class { 'docker::install': } ->
   class { 'docker::config': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,8 +38,17 @@ class docker::install {
           required_packages => 'debian-keyring debian-archive-keyring',
           key               => 'A88D21E9',
           key_source        => 'http://get.docker.io/gpg',
-          pin               => '10',
+          pin               => $docker::apt_source_pin_level,
           include_src       => false,
+        }
+        if $docker::apt_source_pin_level == undef {
+
+          # remove any existing origin-based pin
+          apt::pin { 'docker':
+              ensure => 'absent',
+              origin => 'get.docker.io',
+          }
+          -> Package['docker']
         }
         if $docker::manage_package {
           Apt::Source['docker'] -> Package['docker']

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,19 +38,20 @@ class docker::install {
           required_packages => 'debian-keyring debian-archive-keyring',
           key               => 'A88D21E9',
           key_source        => 'http://get.docker.io/gpg',
-          pin               => $docker::apt_source_pin_level,
           include_src       => false,
         }
-        if $docker::apt_source_pin_level == undef {
 
-          # remove any existing origin-based pin
-          apt::pin { 'docker':
-              ensure => 'absent',
-              origin => 'get.docker.io',
-          }
-          -> Package['docker']
+        apt::pin { 'docker':
+          ensure => $docker::pin_upstream_package_source ? {
+              true    => 'present',
+              default => 'absent',
+          },
+          origin   => 'get.docker.io',
+          priority => $docker::apt_source_pin_level,
         }
+
         if $docker::manage_package {
+          Apt::Pin['docker']    -> Package['docker']
           Apt::Source['docker'] -> Package['docker']
         }
       } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class docker::params {
   $socket_bind                  = 'unix:///var/run/docker.sock'
   $socket_group                 = undef
   $use_upstream_package_source  = true
+  $apt_source_pin_level         = 10
   $service_state                = running
   $service_enable               = true
   $root_dir                     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,6 @@ class docker::params {
   $socket_bind                  = 'unix:///var/run/docker.sock'
   $socket_group                 = undef
   $use_upstream_package_source  = true
-  $apt_source_pin_level         = 10
   $service_state                = running
   $service_enable               = true
   $root_dir                     = undef


### PR DESCRIPTION
Apt pins are...  Interesting.  The hardcoded "10" was sufficient to keep my
system from allowing me to update lxc-docker via the expected means.

This changeset allows one to override the default pin priority level via
`apt_source_pin_level`, or even disable it completely via

``` pin_upstream_package_source```.
```
