### PR TITLE
Use --dns for setting docker's dns servers

### DIFF
--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -25,6 +25,6 @@ DOCKER_OPTS="\
 <% if @tcp_bind %>-H <%= @tcp_bind %> <% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %> <% end -%>
 <% if @socket_group %> -G <%= @socket_group %> <% end -%>
-<% if @dns %> -dns <%= @dns %> <% end -%>
+<% if @dns %> --dns <%= @dns %> <% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %> <% end %><% end -%>
 "

--- a/templates/etc/init/docker.conf.erb
+++ b/templates/etc/init/docker.conf.erb
@@ -9,6 +9,5 @@ stop on runlevel [!2345]
 respawn
 
 script
-<% if @proxy %>http_proxy=<%= @proxy %> https_proxy=<%= @proxy %> <% end %><% if @no_proxy %>no_proxy=<%= @no_proxy %> <% end %> exec /usr/bin/<%= @docker_command %> -d <% if @root_dir %>-g <%= @root_dir %> <% end %><% if @execdriver %>-e <%= @execdriver %> <% end %><% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @dns %> -dns <%= @dns %><% end %><% if @socket_group %> -G <%= @socket_group %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>
+<% if @proxy %>http_proxy=<%= @proxy %> https_proxy=<%= @proxy %> <% end %><% if @no_proxy %>no_proxy=<%= @no_proxy %> <% end %> exec /usr/bin/<%= @docker_command %> -d <% if @root_dir %>-g <%= @root_dir %> <% end %><% if @execdriver %>-e <%= @execdriver %> <% end %><% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @dns %> --dns <%= @dns %><% end %><% if @socket_group %> -G <%= @socket_group %><% end %><% if @extra_parameters %><% @extra_parameters.each do |param| %> <%= param %><% end %><% end %>
 end script
-


### PR DESCRIPTION
The '-dns' option is deprecated and should be replaced by '--dns'
instead.
