### PR TITLE
Allow adding extra parameters to docker::run resources

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -22,6 +22,7 @@ define docker::run(
   $restart_service = true,
   $disable_network = false,
   $privileged = false,
+  $extra_parameters = undef,
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command
@@ -52,6 +53,7 @@ define docker::run(
   $dns_array = any2array($dns)
   $links_array = any2array($links)
   $lxc_conf_array = any2array($lxc_conf)
+  $extra_parameters_array = any2array($extra_parameters)
 
   $sanitised_title = regsubst($title, '[^0-9A-Za-z.\-]', '-')
 
@@ -108,4 +110,3 @@ define docker::run(
     File[$initscript] -> Service["docker-${sanitised_title}"]
   }
 }
-

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -128,6 +128,15 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--privileged/) }
     end
 
+    context 'when passing serveral extra parameters' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'extra_parameters' => ['--rm', '-w /tmp']} }
+      it { should contain_file(initscript).with_content(/--rm/).with_content(/-w \/tmp/) }
+    end
+
+    context 'when passing an extra parameter' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+      it { should contain_file(initscript).with_content(/-c 4/) }
+    end
 
     context 'when passing a data volume' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'volumes' => '/var/log'} }

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -80,6 +80,9 @@ start() {
         <% end %> \
         <% if @use_name %>--name <%= @name %><% end %> \
         <%= @image %> \
+        <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
+            <%= param %> <% end %> \
+        <% end -%> \
         <% if @command %> <%= @command %><% end %>
     retval=$?
     echo

--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -45,6 +45,9 @@ script
         "--link #{link}" }.join(' ') %> \
     <% end %> \
     <% if @use_name %>--name <%= @name %><% end %> \
+    <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
+      <%= param %> <% end %> \
+    <% end -%> \
     <%= @image %> \
     <% if @command %> <%= @command %><% end %> &&
   exec <%= @docker_command %> wait "$(cat /var/run/docker-<%= @title %>.cid)"
@@ -81,6 +84,9 @@ script
         "--link #{link}" }.join(' ') %> \
     <% end %> \
     <% if @use_name %>--name <%= @name %><% end %> \
+    <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
+      <%= param %> <% end %> \
+    <% end -%> \
     <%= @image %> \
     <% if @command %> <%= @command %><% end %> &&
   exec <%= @docker_command %> wait "$(cat /var/run/docker-<%= @title %>.cid)"


### PR DESCRIPTION
This adds an extra parameter 'extra_parameters' to the docker::run
resource similar to the one in docker::service. This allows one to
pass extra arguments to the 'docker run' command which cannot be
passed directly using the other available parameters in the resource.
