### PR TITLE
Added prerequired_packages parameter to selectivly control additional dependencies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,10 @@
 #   Passed to the docker package.
 #   Defaults to present
 #
+# [*prerequired_packages*]
+#   An array of additional packages that need to be installed to support
+#   docker. Defaults change depending on the operating system.
+#
 # [*tcp_bind*]
 #   The tcp socket to bind to in the format
 #   tcp://127.0.0.1:4243
@@ -83,6 +87,7 @@
 class docker(
   $version                     = $docker::params::version,
   $ensure                      = $docker::params::ensure,
+  $prerequired_packages        = $docker::params::prerequired_packages,
   $tcp_bind                    = $docker::params::tcp_bind,
   $socket_bind                 = $docker::params::socket_bind,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,15 +10,9 @@ class docker::install {
   validate_string($::kernelrelease)
   validate_bool($docker::use_upstream_package_source)
 
-  $prerequired_packages = $::operatingsystem ? {
-    'Debian' => ['apt-transport-https', 'cgroupfs-mount'],
-    'Ubuntu' => ['apt-transport-https', 'cgroup-lite', 'apparmor'],
-    default  => '',
-  }
-
   case $::osfamily {
     'Debian': {
-      ensure_packages($prerequired_packages)
+      ensure_packages($docker::prerequired_packages)
       if $docker::manage_package {
         Package['apt-transport-https'] -> Package['docker']
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,4 +56,14 @@ class docker::params {
       $docker_command = $docker_command_default
     }
   }
+
+  # Special extra packages are required on some OSes.
+  # Specifically apparmor is needed for Ubuntu:
+  # https://github.com/docker/docker/issues/4734
+  $prerequired_packages = $::operatingsystem ? {
+    'Debian' => ['apt-transport-https', 'cgroupfs-mount'],
+    'Ubuntu' => ['apt-transport-https', 'cgroup-lite', 'apparmor'],
+    default  => '',
+  }
+
 }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -11,7 +11,7 @@ describe 'docker', :type => :class do
           :lsbdistid              => 'Ubuntu',
           :lsbdistcodename        => 'maverick',
           :kernelrelease          => '3.8.0-29-generic',
-	        :operatingsystemrelease => '10.04',
+          :operatingsystemrelease => '10.04',
         } }
         service_config_file = '/etc/default/docker'
 
@@ -27,13 +27,13 @@ describe 'docker', :type => :class do
           it { should contain_package('docker').with_name('lxc-docker-0.5.5').with_ensure('present') }
         end
 
-	      context 'with a custom package name' do
+        context 'with a custom package name' do
           let(:params) { {'package_name' => 'docker-custom-pkg-name' } }
           it { should contain_package('docker').with_name('docker-custom-pkg-name').with_ensure('present') }
         end
 
-	      context 'with a custom package name and version' do
-	        let(:params) { {
+        context 'with a custom package name and version' do
+          let(:params) { {
              'version'      => '0.5.5',
              'package_name' => 'docker-custom-pkg-name',
           } }
@@ -43,6 +43,12 @@ describe 'docker', :type => :class do
         context 'when not managing the package' do
           let(:params) { {'manage_package' => false } }
           it { should_not contain_package('docker') }
+        end
+
+        context 'It should accept custom prerequired_packages' do
+          let(:params) { {'prerequired_packages' => [ 'test_package' ],
+                          'manage_package'       => false,  } }
+          it { should contain_package('test_package').with_ensure('present') }
         end
 
         context 'with no upstream package source' do


### PR DESCRIPTION
In my environment, we do _not_ use apparmor.
It is not a strict dependency: https://github.com/docker/docker/issues/4734

I think the puppet module should reflect that. Not everyone needs Apparmor installed, and maybe they don't use cgroup-lite (we don't)

This PR makes it an input so it can be controlled.
Also it is nice to have this kind of per-distro-os logic in params.
