### PR TITLE
Remove deprecated "-t" option in docker pull

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -34,7 +34,7 @@ define docker::image(
   }
 
   if $image_tag {
-    $image_install = "${docker_command} pull -t=\"${image_tag}\" ${image}"
+    $image_install = "${docker_command} pull ${image}:${image_tag}"
     $image_remove  = "${docker_command} rmi ${image_force}${image}:${image_tag}"
     $image_find    = "${docker_command} images | grep ^${image} | awk '{ print \$2 }' | grep ${image_tag}"
   } else {

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -26,7 +26,7 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => present and image_tag => precise' do
     let(:params) { { 'ensure' => 'present', 'image_tag' => 'precise' } }
-    it { should contain_exec('docker pull -t="precise" base') }
+    it { should contain_exec('docker pull base:precise') }
   end
 
   context 'with ensure => latest' do
@@ -36,7 +36,7 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => latest and image_tag => precise' do
     let(:params) { { 'ensure' => 'latest', 'image_tag' => 'precise' } }
-    it { should contain_exec('docker pull -t="precise" base') }
+    it { should contain_exec('docker pull base:precise') }
   end
 
   context 'with an invalid image name' do


### PR DESCRIPTION
The "-t" option in docker pull is deprecated and the image tag is
specified as REPOSITORY:TAG.
