### PR TITLE
Removed setuid root in the docker run upstart script

### DIFF
--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -7,8 +7,6 @@ author "Gareth Rushgrove"
 start on (started <%= @service_name %>)
 stop on stopping <%= @service_name %>
 
-setuid root
-
 respawn
 respawn limit 5 20
 


### PR DESCRIPTION
The setuid directive is not supported on the upstart in lucid. (causes the script to be "Unknown Job")

All upstart scripts run as root by default, this part is redundant. 

cc @EvanKrall 
