### PR TITLE
Update docker-run.conf.erb

### DIFF
--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -4,7 +4,7 @@
 description "start and stop <%= @title %> in docker"
 author "Gareth Rushgrove"
 
-start on (started <%= @service_name %>)
+start on filesystem and started <%= @service_name %>
 stop on stopping <%= @service_name %>
 
 setuid root


### PR DESCRIPTION
Altered the startup command based on documentation available here: [https://docs.docker.com/articles/host_integration/](https://docs.docker.com/articles/host_integration/)

Resolves an issue where the upstart script isn't ever being executed.
