### PR TITLE
Docker requires $HOME to read .dockercfg

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -51,14 +51,16 @@ define docker::image(
     }
   } elsif $ensure == 'latest' {
     exec { $image_install:
-      path    => ['/bin', '/usr/bin'],
-      timeout => 0,
+      environment => 'HOME=/root',
+      path        => ['/bin', '/usr/bin'],
+      timeout     => 0,
     }
   } else {
     exec { $image_install:
-      path    => ['/bin', '/usr/bin'],
-      unless  => $image_find,
-      timeout => 0,
+      environment => 'HOME=/root',
+      path        => ['/bin', '/usr/bin'],
+      unless      => $image_find,
+      timeout     => 0,
     }
   }
 }


### PR DESCRIPTION
.dockercfg is where credentials for private registries are stored. Assuming this file is present (downstream module or a future docker::login resource), this allows #113 to move forward.
