### PR TITLE
ensure prerequired_packages are latest

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@ class docker::install {
 
   case $::osfamily {
     'Debian': {
-      ensure_packages($docker::prerequired_packages)
+      ensure_packages($docker::prerequired_packages, {'ensure' => 'latest'})
       if $docker::manage_package {
         Package['apt-transport-https'] -> Package['docker']
       }


### PR DESCRIPTION
There's a bug in 2.7.102-0ubuntu3.7ish? that can prevent docker from running.

I'm not sure what your philosophy is on package version management in debian, but I'm all for taking in the latest version from the official repo. I suppose this could introduce problems if people are mixing repos, distributions, and pinning. How comprehensive should this module be in that regard? I guess I'll leave that up to you.
