### PR TITLE
Changed APT key source to use https to avoid warning from Docker.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,7 +31,7 @@ class docker::install {
           repos             => 'main',
           required_packages => 'debian-keyring debian-archive-keyring',
           key               => 'A88D21E9',
-          key_source        => 'http://get.docker.io/gpg',
+          key_source        => 'https://get.docker.io/gpg',
           pin               => '10',
           include_src       => false,
         }


### PR DESCRIPTION
Got a warning yesterday but can't seem to reproduce it today. Anyhow it seems like the official documentation prefers HTTPS over HTTP. 
