### PR TITLE
when container isn't running, make /etc/init.d/docker-run.erb return 1

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -122,6 +122,10 @@ case "$1" in
     stop
     ;;
     status)
+    if [ "false" = "$(docker inspect --format='{{.State.Running}}' $(cat $cidfile))"  ] ; then
+        echo $prog not running
+        exit 1
+    fi
     docker inspect $(cat $cidfile)
     ;;
     restart|reload)


### PR DESCRIPTION
Puppet isn't restarting stopped containers because `/etc/init.d/docker-<container-name> status` is exiting with status code 0 when the container is not running. This corrects that.
