### PR TITLE
Default the package name for Amazon Linux to docker

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class docker::params {
       $package_source_location = 'https://get.docker.io/ubuntu'
     }
     'RedHat' : {
-      if (versioncmp($::operatingsystemrelease, '7.0') < 0) {
+      if (versioncmp($::operatingsystemrelease, '7.0') < 0) and $::operatingsystem != 'Amazon' {
         $package_name   = 'docker-io'
       } else {
         $package_name   = 'docker'


### PR DESCRIPTION
The package name in Amazon Linux is docker.
