### PR TITLE
Moved extra parameters before image in init.d/docker-run.erb

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -79,11 +79,11 @@ start() {
             "--link #{link}" }.join(' ') %> \
         <% end %> \
         <% if @use_name %>--name <%= @name %><% end %> \
-        <%= @image %> \
         <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
             <%= param %> <% end %> \
         <% end -%> \
-        <% if @command %> <%= @command %><% end %>
+        <%= @image %> \
+       <% if @command %> <%= @command %><% end %>
     retval=$?
     echo
     if [ $retval -eq 0 ]; then


### PR DESCRIPTION
Just a quick ordering fix. The previous ordering was failing on service startup (CentOS6.5)
