### PR TITLE
remove slashes from title when creating filenames

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -25,7 +25,7 @@
 . /etc/init.d/functions
 
 docker="/usr/bin/<%= docker_command %>"
-prog="docker-<%= @title %>"
+prog="docker-<%= @title.gsub('/','-') %>"
 cidfile="/var/run/$prog.cid"
 lockfile="/var/lock/subsys/$prog"
 


### PR DESCRIPTION
With a docker image name in the style of `username/image-name`, the forward slash is evaluated as a path separator. This causes service startup to fail because `/var/run/username` isn't a directory.
