### PR TITLE
Fix volumes from

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -12,7 +12,7 @@ define docker::run(
   $links = [],
   $use_name = false,
   $running = true,
-  $volumes_from = false,
+  $volumes_from = [],
   $net = 'bridge',
   $username = false,
   $hostname = false,
@@ -50,6 +50,7 @@ define docker::run(
   $ports_array = any2array($ports)
   $expose_array = any2array($expose)
   $volumes_array = any2array($volumes)
+  $volumes_from_array = any2array($volumes_from)
   $env_array = any2array($env)
   $dns_array = any2array($dns)
   $links_array = any2array($links)

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -91,6 +91,12 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--volumes-from 6446ea52fbc9/) }
     end
 
+    context 'when connecting to several shared data volumes' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'volumes_from' => ['sample-linked-container-1', 'sample-linked-container-2']} }
+      it { should contain_file(initscript).with_content(/--volumes-from sample-linked-container-1/) }
+      it { should contain_file(initscript).with_content(/--volumes-from sample-linked-container-2/) }
+    end
+
     context 'when passing several port numbers' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'ports' => ['4444', '4555']} }
       it { should contain_file(initscript).with_content(/-p 4444/).with_content(/-p 4555/) }

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -69,7 +69,9 @@ start() {
         <% if @volumes %><% @volumes_array.each do |volume| %> \
             -v <%= volume %><% end %> \
         <% end %> \
-        <% if @volumes_from %> --volumes-from <%= @volumes_from %><% end %> \
+        <% if @volumes_from %><% @volumes_from_array.each do |container| %> \
+            --volumes-from <%= container %><% end %> \
+        <% end %> \
         <% if @net %>--net <%= @net %><% end %> \
         <% if @lxc_conf_array %><% @lxc_conf_array.each do |lxcconf| %> \
             --lxc-conf="<%=lxcconf%>"<% end %> \

--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -35,7 +35,9 @@ script
     <% if @volumes %><% @volumes_array.each do |volume| %> \
         -v <%= volume %><% end %> \
     <% end %> \
-    <% if @volumes_from %> --volumes-from <%= @volumes_from %><% end %> \
+    <% if @volumes_from %><% @volumes_from_array.each do |container| %> \
+        --volumes-from <%= container %><% end %> \
+    <% end %> \
     <% if @net %>--net <%= @net %><% end %> \
     <% if @lxc_conf_array %><% @lxc_conf_array.each do |lxcconf| %> \
         --lxc-conf="<%=lxcconf%>"<% end %> \

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -32,7 +32,9 @@ ExecStart=/usr/bin/<%= @docker_command %> run \
         <% if @volumes %><% @volumes_array.each do |volume| %> \
             -v <%= volume %><% end %> \
         <% end %> \
-        <% if @volumes_from %> --volumes-from <%= @volumes_from %><% end %> \
+        <% if @volumes_from %><% @volumes_from_array.each do |container| %> \
+            --volumes-from <%= container %><% end %> \
+        <% end %> \
         <% if @net %>--net <%= @net %><% end %> \
         <% if @lxc_conf_array %><% @lxc_conf_array.each do |lxcconf| %> \
             --lxc-conf="<%=lxcconf%>"<% end %> \


### PR DESCRIPTION
Clean up upstart script, which had many duplicated lines: one of which wasn't updated and caused a bug with using the deprecated `-volumes-from` instead of `--volumes-from` when the container was named. 

Also fixes `--volumes-from` parameter when its value is an array. Includes a test for this. 
