### PR TITLE
Added Major Release Case Switch For Run Ressource

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -72,11 +72,22 @@ define docker::run(
       $mode = '0644'
     }
     'RedHat': {
-      $initscript = "/etc/init.d/docker-${sanitised_title}"
-      $init_template = 'docker/etc/init.d/docker-run.erb'
-      $hasstatus  = undef
-      $hasrestart = undef
-      $mode = '0755'
+      case $::operatingsystemmajrelease {
+        '7': {
+          $initscript    = "/etc/systemd/system/docker-${sanitised_title}.service"
+          $init_template = 'docker/etc/systemd/system/docker-run.erb'
+          $hasstatus     = true
+          $hasrestart    = true
+          $mode          = '0644'
+        }
+        default: {
+          $initscript = "/etc/init.d/docker-${sanitised_title}"
+          $init_template = 'docker/etc/init.d/docker-run.erb'
+          $hasstatus  = undef
+          $hasrestart = undef
+          $mode = '0755'
+        }
+      }
     }
     'Archlinux': {
       $initscript    = "/etc/systemd/system/docker-${sanitised_title}.service"


### PR DESCRIPTION
Dear all,

on centos 7 or rhel 7 i would appreciate to use the systemd service files.
I added a case switch for rhel / centos 7 to use the archlinux systemd files.
For me it is working as expected and my travis job runned well.
https://travis-ci.org/hingstarne/garethr-docker/builds/40001509
Cheers
