### PR TITLE
Adding start support to stopped containers when use_name is defined.

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -50,7 +50,7 @@ start() {
 
     printf "Starting $prog:\t"
     <% if @use_name -%>
-        $docker inspect <%= @name %> && $docker start -a <%= @name %>
+        $docker inspect <%= @name %> && $docker start <%= @name %>
         $docker inspect <%= @name %> || $docker run --cidfile=$cidfile -d=true \
     <% else -%>
         $docker run --cidfile=$cidfile -d=true \


### PR DESCRIPTION
This is to solve the issue raised in https://github.com/garethr/garethr-docker/issues/160

use_name was causing issues under RedHat as it would attempt to start a new container with the same name rather than start the existing container.  We now check for the existence of this container before starting.

Note: Interactive and attach were removed from the RedHat version as the current init script forces detached mode anyway.  Detach (or attachment support in general) needs a slight overhaul and will likely be handled in a future PR.
