### PR TITLE
Set enviornment for  /root/.docker.cfg support

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -9,6 +9,7 @@ Requires=docker.service
 [Service]
 <%- if @username -%>User=<%= @username %><%- end -%>
 TimeoutStartSec=0
+Environment="HOME=/root"
 ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 ExecStartPre=-/usr/bin/<%= @docker_command %> rm <%= @sanitised_title %>
 ExecStartPre=/usr/bin/<%= @docker_command %> pull <%= @image %>


### PR DESCRIPTION
Containers pulled from authenticated repos will not work unless they HOME variable point to the directory
where .docker.cfg is. I've chosen to hardcode the path to root, because that's the standard location.
