### PR TITLE
actually make use of docker::run pull_on_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,12 @@ docker::run { 'helloworld':
   dns             => ['8.8.8.8', '8.8.4.4'],
   restart_service => true,
   privileged      => false,
+  pull_on_start   => false,
 }
 ```
 
 Ports, expose, env, dns and volumes can be set with either a single string or as above with an array of values.
+Specifying pull_on_start will pull the image before each time it is started.
 
 To use an image tag just append the tag name to the image name separated by a semicolon:
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -26,6 +26,7 @@ define docker::run(
   $privileged = false,
   $detach = false,
   $extra_parameters = undef,
+  $pull_on_start = false,
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -166,7 +166,7 @@ require 'spec_helper'
       let(:params) { {'command' => 'command', 'image' => 'base', 'privileged' => true} }
       it { should contain_file(initscript).with_content(/--privileged/) }
     end
-    
+
     context 'when running detached' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'detach' => true} }
       it { should contain_file(initscript).with_content(/--detach=true/) }
@@ -196,6 +196,16 @@ require 'spec_helper'
     context 'when using network mode' do
       let(:params) { {'command' => 'command', 'image' => 'nginx', 'net' => 'host'} }
       it { should contain_file(initscript).with_content(/--net host/) }
+    end
+
+    context 'when `pull_on_start` is true' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'pull_on_start' => true } }
+      it { should contain_file(initscript).with_content(/docker pull base/) }
+    end
+
+    context 'when `pull_on_start` is false' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'pull_on_start' => false } }
+      it { should_not contain_file(initscript).with_content(/docker pull base/) }
     end
 
     context 'with an title that will not format into a path' do

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -75,6 +75,9 @@ start() {
     fi
 
     printf "Starting $prog:\t"
+    <% if @pull_on_start -%>
+        $docker pull <%= @image %>
+    <% end -%>
     <% if @use_name -%>
         $docker inspect <%= @name %> && $docker start <%= @name %>
         $docker inspect <%= @name %> || $docker run --cidfile=$cidfile -d=true \

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -12,7 +12,7 @@ TimeoutStartSec=0
 Environment="HOME=/root"
 ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 ExecStartPre=-/usr/bin/<%= @docker_command %> rm <%= @sanitised_title %>
-ExecStartPre=/usr/bin/<%= @docker_command %> pull <%= @image %>
+<%- if @pull_on_start %>ExecStartPre=/usr/bin/<%= @docker_command %> pull <%= @image %><% end -%>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <% if @username %>-u '<%= @username %>' <% end %> \
         <% if @hostname %>-h '<%= @hostname %>'<% end %> \


### PR DESCRIPTION
- This is documented in the README, but wasn't really used anywhere.
- The systemd template by default pulls, which clearly isn't going to
  work if the image is not in a registry, but is built via
  docker::image with Dockerfile or so.
