### PR TITLE
patch to garethr-docker#165

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ spec/fixtures
 .vagrant
 .yardoc
 doc
+*.swp
+.ruby-version

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,9 @@
 #   Any extra parameters that should be passed to the docker daemon.
 #   Defaults to undefined
 #
+# [*shell_values*]
+#   Array of shell values to pass into init script config files
+#
 # [*proxy*]
 #   Will set the http_proxy and https_proxy env variables in /etc/sysconfig/docker (redhat/centos) or /etc/default/docker (debian)
 #
@@ -105,6 +108,7 @@ class docker(
   $dns_search                  = $docker::params::dns_search,
   $socket_group                = $docker::params::socket_group,
   $extra_parameters            = undef,
+  $shell_values                = undef,
   $proxy                       = $docker::params::proxy,
   $no_proxy                    = $docker::params::no_proxy,
   $storage_driver              = $docker::params::storage_driver,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,9 @@
 # [*extra_parameters*]
 #   Plain additional parameters to pass to the docker daemon
 #
+# [*shell_values*]
+#   Array of shell values to pass into init script config files
+#
 class docker::service (
   $docker_command       = $docker::docker_command,
   $service_name         = $docker::service_name,
@@ -30,6 +33,7 @@ class docker::service (
   $service_enable       = $docker::service_enable,
   $root_dir             = $docker::root_dir,
   $extra_parameters     = $docker::extra_parameters,
+  $shell_values         = $docker::shell_values,
   $proxy                = $docker::proxy,
   $no_proxy             = $docker::no_proxy,
   $execdriver           = $docker::execdriver,
@@ -39,6 +43,7 @@ class docker::service (
   $dns_array = any2array($dns)
   $dns_search_array = any2array($dns_search)
   $extra_parameters_array = any2array($extra_parameters)
+  $shell_values_array = any2array($shell_values)
 
   case $::osfamily {
     'Debian': {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -179,6 +179,17 @@ describe 'docker', :type => :class do
         it { should contain_file(service_config_file).with_content(/--this this/) }
       end
 
+      context 'with multi shell values' do
+        let(:params) { {'shell_values' => ['--this this', '--that that'] } }
+        it { should contain_file(service_config_file).with_content(/--this this/) }
+        it { should contain_file(service_config_file).with_content(/--that that/) }
+      end
+
+      context 'with a string shell values' do
+        let(:params) { {'shell_values' => '--this this' } }
+        it { should contain_file(service_config_file).with_content(/--this this/) }
+      end
+
       context 'with socket group set' do
         let(:params) { { 'socket_group' => 'notdocker' }}
         it { should contain_file(service_config_file).with_content(/-G notdocker/) }

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -19,3 +19,6 @@ export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
 export TMPDIR="<%= @tmp_dir %>"
+<% if @shell_values %><% @shell_values_array.each do |param| %>
+<%= param %><% end %><% end -%>
+

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -29,3 +29,5 @@ DOCKER_OPTS="\
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 "
+<% if @shell_values %><% @shell_values_array.each do |param| %>
+<%= param %><% end %><% end %>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -19,3 +19,5 @@ export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
 export TMPDIR="<%= @tmp_dir %>"
+<% if @shell_values %><% @shell_values_array.each do |param| %>
+<%= param %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -2,3 +2,5 @@
 # may be overwritten
 
 OPTIONS=<%- if @root_dir %>-g <%= @root_dir %><%- end %> <%- if @tcp_bind %>-H <%= @tcp_bind %><%- end %><%- if @socket_bind %> -H <%= @socket_bind %><%- end %> <%- if @socket_group %> -G <%= @socket_group %><%- end %> <%- if @execdriver %> -e <%= @execdriver %> <%- end %> <%- if @storage_driver %> --storage-driver=<%= @storage_driver %><%- end %> <%- if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><%- end %><%- end %>
+<% if @shell_values %><% @shell_values_array.each do |param| %>
+<%= param %><% end %><% end %>


### PR DESCRIPTION
Ignoring my .ruby-versions and vim swap files

Adding tests

We don't need a test for the run define

Adding ability to pass shell values into init cfg files

This should allow you to pass an array of shell commands to the
end of the sysconfig/docker files