### PR TITLE
docker::run - add Restart support to systemd unit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Specifying `pull_on_start` will pull the image before each time it is started.
 
 The `depends` option allows expressing containers that must be started before. This affects the generation of the init.d/systemd script.
 
+The service file created for systemd and upstart based systems enables automatic restarting of the service on failure by default.
+
 To use an image tag just append the tag name to the image name separated by a semicolon:
 
 ```puppet

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -54,6 +54,13 @@ require 'spec_helper'
       end
     end
 
+    context 'with autorestart functionality' do
+      let(:params) { {'command' => 'command', 'image' => 'base'} }
+      if (systemd)
+        it { should contain_file(initscript).with_content(/Restart=on-failure/) }
+      end
+    end
+
     context 'when lxc_conf disables swap' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'lxc_conf' => 'lxc.cgroup.memory.memsw.limit_in_bytes=536870912'} }
       it { should contain_file(initscript).with_content(/-lxc-conf=\"lxc.cgroup.memory.memsw.limit_in_bytes=536870912\"/) }

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -8,6 +8,9 @@ Requires=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| 
 
 [Service]
 <%- if @username -%>User=<%= @username %><%- end -%>
+Restart=on-failure
+StartLimitInterval=20
+StartLimitBurst=5
 TimeoutStartSec=0
 Environment="HOME=/root"
 ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>


### PR DESCRIPTION
I've also updated the upstart file, but as far as I can see, that one isn't actually used anymore.