### PR TITLE
bring sysconfig template for RHEL7 and Fedora up-to-date for DNS

### DIFF
--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -1,4 +1,19 @@
 # This file is managed by Puppet and local changes
 # may be overwritten
 
-OPTIONS=<%- if @root_dir %>-g <%= @root_dir %><%- end %> <%- if @tcp_bind %>-H <%= @tcp_bind %><%- end %><%- if @socket_bind %> -H <%= @socket_bind %><%- end %> <%- if @socket_group %> -G <%= @socket_group %><%- end %> <%- if @execdriver %> -e <%= @execdriver %> <%- end %> <%- if @storage_driver %> --storage-driver=<%= @storage_driver %><%- end %> <%- if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><%- end %><%- end %>
+OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @socket_group %> -G <%= @socket_group %><% end -%>
+<% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
+<% if @execdriver %> -e <%= @execdriver %> <% end -%>
+<% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
+"
+
+<% if @proxy %>export http_proxy='<%= @proxy %>'
+  export https_proxy='<%= @proxy %>'<% end %>
+<% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>
+# This is also a handy place to tweak where Docker's temporary files go.
+# export TMPDIR="<%= @tmp_dir %>"


### PR DESCRIPTION
The template for RHEL7/CentOS7/Fedora was not setting DNS servers and search path in /etc/sysconfig/docker. This template is very similar to the one used on other platforms and the two could/should probably be consolidated. 

Sorry, but I'm in a crunch so I just "modernized" the CentOS7/etc version as I didn't have time to dive into the spec and acceptance testing and make the proper prep for merging the two templates and testing the conditional logic. FWIW, I have tested this branch on a live VM I've been using for testing of Jenkins + Docker work and things look fine.