### PR TITLE
Fix sysconfig parameters being ignored

### DIFF
--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -11,8 +11,8 @@ other_args="<% -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
-<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
-"
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>"
+
 <% if @proxy %>export http_proxy='<%= @proxy %>'
 export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -9,8 +9,7 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
-<% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>
-"
+<% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>"
 
 <% if @proxy %>export http_proxy='<%= @proxy %>'
   export https_proxy='<%= @proxy %>'<% end %>


### PR DESCRIPTION
Before this patch:

```
OPTIONS=" -H unix:///var/run/docker.sock --storage-driver=devicemapper --insecure-registry 127.0.0.1:5000
"
```

```
# ps aux | grep -i docker
root     36598  0.0  0.1 135500  4500 ?        Ss   08:22   0:00 sshd: docker [priv]
docker   36603  0.0  0.0 135612  2280 ?        S    08:22   0:00 sshd: docker@pts/1
docker   36604  0.0  0.0 115612  2216 pts/1    Ss+  08:22   0:00 /bin/sh
root     44711  3.5  0.2 423260 11472 ?        Ssl  10:57   0:00 /usr/bin/docker -d
root     44753  0.0  0.0 112640   968 pts/3    S+   10:57   0:00 grep --color=auto -i docker
```
After:

```
OPTIONS=" -H unix:///var/run/docker.sock --storage-driver=devicemapper --insecure-registry 127.0.0.1:5000"
```

```
# ps aux | grep -i docker
root     36598  0.0  0.1 135500  4500 ?        Ss   08:22   0:00 sshd: docker [priv]
docker   36603  0.0  0.0 135612  2280 ?        S    08:22   0:00 sshd: docker@pts/1
docker   36604  0.0  0.0 115612  2216 pts/1    Ss+  08:22   0:00 /bin/sh
root     44660  0.0  0.2 292244 11304 ?        Ssl  10:55   0:00 /usr/bin/docker -d -H unix:///var/run/docker.sock --storage-driver=devicemapper --insecure-registry 127.0.0.1:5000
root     44703  0.0  0.0 112640   972 pts/3    S+   10:57   0:00 grep --color=auto -i docker
```