### PR TITLE
add requirement for shellwords

### DIFF
--- a/lib/puppet/parser/functions/docker_exec_flags.rb
+++ b/lib/puppet/parser/functions/docker_exec_flags.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Puppet::Parser::Functions
   # Transforms a hash into a string of docker exec flags
   newfunction(:docker_exec_flags, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module Puppet::Parser::Functions
   # Transforms a hash into a string of docker flags
   newfunction(:docker_run_flags, :type => :rvalue) do |args|


### PR DESCRIPTION
Hi,

This is a small pull request to add a requirement for shellwords, due to the use of the function 'shellescape' in the files  lib/puppet/parser/functions/docker_exec_flags.rb and lib/puppet/parser/functions/docker_run_flags.rb.

Without this requirement, the use of docker::run failed on my system with the error message 
> Error: undefined method `shellescape' for .. at docker/manifests/run.pp:59

Additionnals info about my system :
> ruby 1.9.3p484 (2013-11-22 revision 43786) [x86_64-linux]
> puppet 3.73

Hope it helps.

Regards,