### PR TITLE
add containment of subclasses into main docker class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,8 +189,10 @@ class docker(
 
   class { 'docker::install': } ->
   class { 'docker::config': } ~>
-  class { 'docker::service': } ->
-  Class['docker']
+  class { 'docker::service': }
+  contain 'docker::install'
+  contain 'docker::config'
+  contain 'docker::service'
 
   # Only bother trying to extra docker stuff after docker has been installed,
   # and is running.


### PR DESCRIPTION
I encounterd an issue with the following code which ensures the disk is properly formatted and mounted before installing docker:
  Profile::Disk::App[$app_name] ->
  class { '::docker': }
Actually Puppet was still installing docker before the disk is ready (docker::install class was applied too early)

This is solved by using containment feature.