### PR TITLE
Fixes Debian init script issue

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -50,11 +50,18 @@ class docker::service (
       $hasstatus     = true
       $hasrestart    = false
 
-      file { '/etc/init.d/docker':
-          ensure => 'link',
-          target => '/lib/init/upstart-job',
-          force  => true,
-          notify => Service['docker'],
+      case $::operatingsystem {
+        'Debian': {
+          # Do nothing as Debian doesn't have Upstart
+        }
+        default: {
+          file { '/etc/init.d/docker':
+              ensure => 'link',
+              target => '/lib/init/upstart-job',
+              force  => true,
+              notify => Service['docker'],
+          }
+        }
       }
 
       file { "/etc/default/${service_name}":


### PR DESCRIPTION
This is a small fix to avoid the init script being deleted on Debian hosts which don't use Upstart.

This allows Debian 7 hosts with the backports kernel to use this module without issue provided the following parameters are set.

```
docker::package_name   => 'lxc-docker',
docker::service_name   => 'docker',
docker::docker_command => 'docker',
```

If you need any others changes let me know!