### PR TITLE
Add hostentries to pass --add-host flags to the docker container

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -57,6 +57,7 @@ module Puppet::Parser::Functions
       ['--volumes-from %s', 'volumes_from'],
       ['-e %s',             'env'],
       ['-p %s',             'ports'],
+      ['--add-host %s',     'hostentries'],
       ['-v %s',             'volumes'],
       ['-H %s',             'socket_connect'],
     ].each do |(format, key)|

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -30,6 +30,7 @@ define docker::run(
   $depends = [],
   $tty = false,
   $socket_connect = [],
+  $hostentries = [],
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command
@@ -79,6 +80,7 @@ define docker::run(
     volumes_from => any2array($volumes_from),
     tty => $tty,
     socket_connect => any2array($socket_connect),
+    hostentries => any2array($hostentries),
   })
 
   $sanitised_title = regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G')

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -131,6 +131,11 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--expose=4666/) }
     end
 
+    context 'when passing a hostentry' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'hostentries' => 'dummyhost:127.0.0.2'} }
+      it { should contain_file(initscript).with_content(/--add-host dummyhost:127.0.0.2/) }
+    end
+
     context 'when connecting to shared data volumes' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'volumes_from' => '6446ea52fbc9'} }
       it { should contain_file(initscript).with_content(/--volumes-from 6446ea52fbc9/) }


### PR DESCRIPTION
I need the ability to pass --add-host flags to the docker init script - this does that.