### PR TITLE
refs #186 init script should still work when 'use_name' is defined

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -79,7 +79,7 @@ start() {
         $docker pull <%= @image %>
     <% end -%>
     <% if @use_name -%>
-        $docker inspect <%= @name %> && $docker start <%= @name %>
+        $docker inspect <%= @name %> && $docker start <%= @name %> && $docker inspect --format='{{.Id}}' <%= @name %> > $cidfile
         $docker inspect <%= @name %> || $docker run --cidfile=$cidfile -d=true \
     <% else -%>
         $docker run --cidfile=$cidfile -d=true \

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -129,11 +129,19 @@ case "$1" in
     stop
     ;;
     status)
-    if [ "false" = "$(docker inspect --format='{{.State.Running}}' $(cat $cidfile))"  ] ; then
+    <% if @use_name -%>
+        if [ "false" = "$($docker inspect --format='{{.State.Running}}' <%= @name %>)"  ] ; then
+    <% else -%>
+        if [ "false" = "$($docker inspect --format='{{.State.Running}}' $(cat $cidfile))"  ] ; then
+    <% end -%>
         echo $prog not running
         exit 1
     fi
-    docker inspect $(cat $cidfile)
+    <% if @use_name -%>
+    $docker inspect <%= @name %>
+    <% else -%>
+    $docker inspect $(cat $cidfile)
+    <% end -%>
     ;;
     restart|reload)
     stop


### PR DESCRIPTION
There are two changes:
1) use name and not cidfile in status function. That's because cidfile gets deleted from stop function, therefore it does not exist when the container is not running and the status function fails.

2) restore cidfile on docker start. We start by name anyway so it is safe to store the cid read via inspect.