### PR TITLE
adding support for log_level (-l) in docker config files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,11 @@
 #   tcp://127.0.0.1:4243
 #   Defaults to undefined
 #
+# [*log_level*]
+#   Set the logging level
+#   Defaults to undef: docker defaults to info if no value specified
+#   Valid values: degug, info, error, fatal
+#
 # [*socket_bind*]
 #   The unix socket to bind to. Defaults to
 #   unix:///var/run/docker.sock.
@@ -134,6 +139,7 @@ class docker(
   $ensure                      = $docker::params::ensure,
   $prerequired_packages        = $docker::params::prerequired_packages,
   $tcp_bind                    = $docker::params::tcp_bind,
+  $log_level                   = $docker::params::log_level,
   $socket_bind                 = $docker::params::socket_bind,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
   $package_source_location     = $docker::params::package_source_location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class docker::params {
   $version                      = undef
   $ensure                       = present
   $tcp_bind                     = undef
+  $log_level                    = undef
   $socket_bind                  = 'unix:///var/run/docker.sock'
   $socket_group                 = undef
   $service_state                = running

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -218,6 +218,11 @@ describe 'docker', :type => :class do
         let(:params) { {'service_enable' => 'true'} }
         it { should contain_service('docker').with_enable('true') }
       end
+      
+      context 'with specific log_level' do
+        let(:params) {{ 'log_level' => 'debug' }}
+        it { should contain_file(service_config_file).with_content(/-l debug/) }
+      end
 
       context 'with custom root dir' do
         let(:params) { {'root_dir' => '/mnt/docker'} }

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -6,6 +6,7 @@ DOCKER="/usr/bin/<%= @docker_command %>"
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -21,6 +21,7 @@ export TMPDIR="<%= @tmp_dir %>"
 DOCKER_OPTS="\
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -6,6 +6,7 @@ DOCKER="/usr/bin/<%= @docker_command %>"
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -3,6 +3,7 @@
 
 OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>


### PR DESCRIPTION
The default log level for docker is 'info' which can generate a lot of noise, just adding support for the -l|--log-level switch in the docker configs.

From the manpage the usage is:
```
       -l, --log-level="debug|info|error|fatal""
         Set the logging level. Default is info.
```

This patch allows the optional docker::params::log_level to be set.