### PR TITLE
adding support for log_level (-l) in docker config files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,11 @@
 #   The unix socket to bind to. Defaults to
 #   unix:///var/run/docker.sock.
 #
+# [*log_level*]
+#   Set the logging level
+#   Defaults to undef: docker defaults to info if no value specified
+#   Valid values: degug, info, error, fatal
+#
 # [*use_upstream_package_source*]
 #   Whether or not to use the upstream package source.
 #   If you run your own package mirror, you may set this
@@ -135,6 +140,7 @@ class docker(
   $prerequired_packages        = $docker::params::prerequired_packages,
   $tcp_bind                    = $docker::params::tcp_bind,
   $socket_bind                 = $docker::params::socket_bind,
+  $log_level                   = $docker::params::log_level,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
   $package_source_location     = $docker::params::package_source_location,
   $service_state               = $docker::params::service_state,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,10 @@ class docker(
   validate_bool($manage_kernel)
   validate_bool($manage_package)
 
+  if $log_level {
+    validate_re($log_level, '^(debug|info|error|fatal)$', 'log_level must be one of debug, info, error or fatal')
+  }
+
   if $storage_driver {
     validate_re($storage_driver, '^(aufs|devicemapper|btrfs|overlay|vfs)$', 'Valid values for storage_driver are aufs, devicemapper, btrfs, overlayfs, vfs.' )
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class docker::params {
   $ensure                       = present
   $tcp_bind                     = undef
   $socket_bind                  = 'unix:///var/run/docker.sock'
+  $log_level                    = undef
   $socket_group                 = undef
   $service_state                = running
   $service_enable               = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -26,6 +26,7 @@ class docker::service (
   $service_name         = $docker::service_name,
   $tcp_bind             = $docker::tcp_bind,
   $socket_bind          = $docker::socket_bind,
+  $log_level            = $docker::log_level,
   $socket_group         = $docker::socket_group,
   $dns                  = $docker::dns,
   $dns_search           = $docker::dns_search,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -219,6 +219,11 @@ describe 'docker', :type => :class do
         it { should contain_service('docker').with_enable('true') }
       end
 
+      context 'with specific log_level' do
+        let(:params) {{ 'log_level' => 'debug' }}
+        it { should contain_file(service_config_file).with_content(/-l debug/) }
+      end
+
       context 'with custom root dir' do
         let(:params) { {'root_dir' => '/mnt/docker'} }
         it { should contain_file(service_config_file).with_content(/-g \/mnt\/docker/) }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -220,8 +220,17 @@ describe 'docker', :type => :class do
       end
 
       context 'with specific log_level' do
-        let(:params) {{ 'log_level' => 'debug' }}
+        let(:params) { { 'log_level' => 'debug' } }
         it { should contain_file(service_config_file).with_content(/-l debug/) }
+      end
+
+      context 'with an invalid log_level' do
+        let(:params) { { 'log_level' => 'verbose'} }
+        it do
+          expect {
+            should contain_package('docker')
+          }.to raise_error(Puppet::Error, /log_level must be one of debug, info, error or fatal/)
+        end
       end
 
       context 'with custom root dir' do

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -7,6 +7,7 @@ other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -22,6 +22,7 @@ DOCKER_OPTS="\
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -7,6 +7,7 @@ other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -4,6 +4,7 @@
 OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @log_level %> -l <%= @log_level %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>


### PR DESCRIPTION
The default log level for docker is 'info' which can generate a lot of noise, just adding support for the -l|--log-level switch in the docker configs: /etc/conf.d/docker, /etc/default/docker, /etc/sysconfig/docker

From the manpage the usage is:

   -l, --log-level="debug|info|error|fatal""
     Set the logging level. Default is info.

This patch allows the optional docker::params::log_level to be set.