### PR TITLE
fix systemd template w.r.t. extra_parameters

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -19,10 +19,10 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> rm <%= @sanitised_title %>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <%= @docker_run_flags %> \
         --name <%= @sanitised_title %> \
-        <%= @image %> \
         <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
             <%= param %> <% end %> \
         <% end -%> \
+        <%= @image %> \
         <% if @command %> <%= @command %><% end %>
 ExecStop=-/usr/bin/<%= @docker_command %> stop <%= @sanitised_title %>
 


### PR DESCRIPTION
The `<%= @image %>` tag should come immediately before the `<%= @command %>` otherwise docker will interpret any `extra_parameters` as the command argument and fail. The existing `/etc/init.d/docker-run.erb` template does this correctly. This fix makes both init.d and systemd templates consistent.