### PR TITLE
Add options for init script to clean .cid file

### DIFF
--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -123,6 +123,18 @@ stop() {
     fi
 }
 
+clean() {
+    if ! [ -f $cidfile ]; then
+        failure
+        echo
+        printf "$cidfile does not exist.\n"
+    else
+        rm $cidfile
+        retval=$?
+        return $retval
+    fi
+}
+
 case "$1" in
     start)
     start
@@ -141,11 +153,19 @@ case "$1" in
     stop
     start
     ;;
+    clean)
+    clean
+    ;;
+    cleanRestart)
+    stop
+    clean
+    start
+    ;;
     condrestart)
     [ -f /var/lock/subsys/$prog ] && restart || :
     ;;
     *)
-    echo "Usage: $0 [start|stop|status|reload|restart|probe]"
+    echo "Usage: $0 [start|stop|status|reload|restart|probe|clean|cleanRestart]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
The current init script writes a .cid file with the container id in /var/run/$prog.cid

If one wishes to pull down a new version of the container and start it up, this cannot be accomplished with the current init script alone since it re-uses the previous container id stored in the .cid file.

This pull request adds a 'clean' option to the init script which will remove the .cid file.  It also provides a cleanRestart option that will stop the container, remove the .cid file, and then start the container up again (with the latest image if if 'docker pull' has a new one available)