### PR TITLE
Improve support for Debian 7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,3 +82,6 @@ Or with Ubuntu 14.04 with:
 
     BEAKER_set=ubuntu-server-1404-x64 bundle exec rake beaker
 
+Or with Debian 7.8 with:
+
+    BEAKER_set=debian-78-x64 bundle exec rake beaker

--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :development do
   gem "guard-rake"
   gem "pry"
   gem "yard"
+  gem "vagrant-wrapper"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/puppetlabs/beaker.git
-  revision: 2d25d06d20ee7e00d353e1df5c530f957e4c8cfa
+  revision: c68967e3d15674c1a39510222e14cfbaf6c59ad6
   specs:
-    beaker (2.8.0)
+    beaker (2.9.0)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)
@@ -20,7 +20,7 @@ GIT
 
 GIT
   remote: https://github.com/rodjek/rspec-puppet.git
-  revision: a9a837669cf6955279f02d1d9b524dc140b9d3e8
+  revision: 7ee8bd6ce2bf5eb8bea319ac22385ae0edde406e
   specs:
     rspec-puppet (2.0.1)
       rspec
@@ -29,21 +29,24 @@ GEM
   remote: http://rubygems.org/
   specs:
     CFPropertyList (2.3.1)
-    activesupport (3.2.21)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activesupport (4.2.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.3.8)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (1.63.0)
-      aws-sdk-v1 (= 1.63.0)
-    aws-sdk-v1 (1.63.0)
+    aws-sdk (1.64.0)
+      aws-sdk-v1 (= 1.64.0)
+    aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     backports (3.6.4)
-    beaker-rspec (5.0.1)
+    beaker-rspec (5.0.2)
       beaker (~> 2.0)
       rspec
       serverspec (~> 2)
@@ -53,14 +56,14 @@ GEM
       timers (~> 4.0.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    docker-api (1.20.0)
+    docker-api (1.21.1)
       excon (>= 0.38.0)
       json
-    domain_name (0.5.23)
+    domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     ethon (0.7.3)
       ffi (>= 1.3.0)
-    excon (0.45.1)
+    excon (0.45.3)
     extlib (0.9.16)
     facter (1.7.6)
     faraday (0.9.1)
@@ -70,13 +73,15 @@ GEM
     ffi (1.9.8)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.28.0)
+    fog (1.29.0)
       fog-atmos
       fog-aws (~> 0.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.3)
+      fog-core (~> 1.27, >= 1.27.4)
       fog-ecloud
       fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-radosgw (>= 0.0.2)
       fog-riakcs
@@ -93,7 +98,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.1.1)
+    fog-aws (0.1.2)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -102,23 +107,30 @@ GEM
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.29.0)
+    fog-core (1.30.0)
       builder
-      excon (~> 0.38)
+      excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-ecloud (0.0.2)
+    fog-ecloud (0.1.1)
       fog-core
       fog-xml
-    fog-json (1.0.0)
+    fog-json (1.0.1)
+      fog-core (~> 1.0)
       multi_json (~> 1.0)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
     fog-profitbricks (0.0.2)
       fog-core
       fog-xml
       nokogiri
-    fog-radosgw (0.0.3)
+    fog-radosgw (0.0.4)
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
@@ -126,28 +138,28 @@ GEM
       fog-core
       fog-json
       fog-xml
-    fog-sakuracloud (1.0.0)
+    fog-sakuracloud (1.0.1)
       fog-core
       fog-json
-    fog-serverlove (0.1.1)
+    fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-softlayer (0.4.1)
+    fog-softlayer (0.4.5)
       fog-core
       fog-json
-    fog-storm_on_demand (0.1.0)
+    fog-storm_on_demand (0.1.1)
       fog-core
       fog-json
-    fog-terremark (0.0.4)
+    fog-terremark (0.1.0)
       fog-core
       fog-xml
-    fog-vmfusion (0.0.1)
+    fog-vmfusion (0.1.0)
       fission
       fog-core
-    fog-voxel (0.0.2)
+    fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-xml (0.1.1)
+    fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
@@ -158,8 +170,8 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (>= 2.7)
       net-http-pipeline
-    google-api-client (0.8.4)
-      activesupport (~> 3.2)
+    google-api-client (0.8.6)
+      activesupport (>= 3.2)
       addressable (~> 2.3)
       autoparse (~> 0.3)
       extlib (~> 0.9)
@@ -190,7 +202,7 @@ GEM
       rake
     hiera (1.3.4)
       json_pure
-    highline (1.7.1)
+    highline (1.7.2)
     hitimes (1.2.2)
     hocon (0.0.7)
     http-cookie (1.0.2)
@@ -213,7 +225,7 @@ GEM
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
     lumberjack (1.0.9)
-    memoist (0.11.0)
+    memoist (0.12.0)
     metaclass (0.0.4)
     metadata-json-lint (0.0.6)
       json
@@ -221,7 +233,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.4.3)
     mini_portile (0.6.2)
-    minitest (5.5.1)
+    minitest (5.6.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.0)
@@ -254,7 +266,7 @@ GEM
       puppet-lint (~> 1.0)
     puppet-syntax (2.0.0)
       rake
-    puppetlabs_spec_helper (0.10.1)
+    puppetlabs_spec_helper (0.10.2)
       mocha
       puppet-lint
       puppet-syntax
@@ -292,7 +304,7 @@ GEM
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
     rsync (1.0.9)
-    serverspec (2.13.0)
+    serverspec (2.14.1)
       multi_json
       rspec (~> 3.0)
       rspec-its
@@ -307,13 +319,14 @@ GEM
     slop (3.6.0)
     spdx-licenses (1.0.0)
       json
-    specinfra (2.27.0)
+    specinfra (2.30.0)
       net-scp
       net-ssh
     thor (0.19.1)
+    thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
-    travis (1.7.5)
+    travis (1.7.6)
       addressable (~> 2.3)
       backports
       faraday (~> 0.9)
@@ -329,10 +342,13 @@ GEM
     trollop (2.1.2)
     typhoeus (0.7.1)
       ethon (>= 0.7.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
-    websocket (1.2.1)
+    unf_ext (0.0.7.1)
+    vagrant-wrapper (2.0.2)
+    websocket (1.2.2)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -355,4 +371,5 @@ DEPENDENCIES
   rspec-puppet!
   travis
   travis-lint
+  vagrant-wrapper
   yard

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This module is currently tested on:
 * Ubuntu 14.04
 * Centos 7.0
 * Centos 6.6
+* Debian 7.8
 
 It may work on other distros and additional operating systems will be
 supported in the future. It's definitely been used with the following
@@ -25,7 +26,6 @@ too:
 * Archlinux
 * Amazon Linux
 * Fedora
-* Debian
 
 ## Examples
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,8 +54,22 @@ class docker::install {
           default: { $kernelpackage = "linux-image-extra-${::kernelrelease}" }
         }
         $manage_kernel = $docker::manage_kernel
-      } else {
-        # Debian does not need extra kernel packages
+      }
+      elsif $::operatingsystem == 'Debian' {
+        case $::lsbmajdistrelease {
+          '7': {
+            # Debian 7 (Wheezy) ships with Kernel 3.2, but Docker requires
+            # Kernel >= 3.8. Install the 3.16 kernel from wheezy-backports.
+            $kernelpackage  = "linux-image-${::architecture}"
+            $manage_kernel  = $docker::manage_kernel
+          }
+          default: {
+            # Debian >= 8 should have a new enough kernel to support Docker.
+            $manage_kernel = false
+          }
+        }
+      }
+      else {
         $manage_kernel = false
       }
     }
@@ -92,9 +106,33 @@ class docker::install {
   }
 
   if $manage_kernel {
-    package { $kernelpackage:
-      ensure => present,
+    if $::lsbdistcodename == 'wheezy' {
+      include apt::backports
+
+      notify { 'please-reboot':
+        message => "Please reboot the system to load Kernel ${docker::kernel_release}",
+        require => Package[$kernelpackage]
+      }
     }
+
+    case $::lsbdistcodename {
+      'wheezy': {
+        $kernelpackage_install_opts = ['-t=wheezy-backports']
+        $kernelpackage_require      = Class['apt::backports']
+      }
+      default: {
+        $kernelpackage_install_opts = undef
+        $kernelpackage_require      = undef
+      }
+    }
+
+    package { $kernelpackage:
+      ensure          => $docker::kernelpackage_version,
+      install_options => $kernelpackage_install_opts,
+      require         => $kernelpackage_require,
+    }
+
+
     if $docker::manage_package {
       Package[$kernelpackage] -> Package['docker']
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,11 @@ class docker::params {
   case $::osfamily {
     'Debian' : {
       case $::operatingsystem {
+        'Debian': {
+          $package_name   = $package_name_default
+          $service_name   = $service_name_default
+          $docker_command = $docker_command_default
+        }
         'Ubuntu' : {
           $package_name   = $package_name_default
           $service_name   = $service_name_default

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,9 +39,18 @@ class docker::params {
     'Debian' : {
       case $::operatingsystem {
         'Debian': {
-          $package_name   = $package_name_default
-          $service_name   = $service_name_default
-          $docker_command = $docker_command_default
+          $package_name          = $package_name_default
+          $service_name          = $service_name_default
+          $docker_command        = $docker_command_default
+
+          if $::lsbdistcodename == 'wheezy' {
+            $kernelpackage_version = '3.16+63~bpo70+1'
+            $kernel_release        = '3.16.0'
+          }
+          else {
+            $kernelpackage_version = 'present'
+            $kernel_release        = undef
+          }
         }
         'Ubuntu' : {
           $package_name   = $package_name_default

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -298,13 +298,14 @@ describe 'docker', :type => :class do
     end
   end
 
-  context 'specific to Debian wheezy' do
+  context 'specific to Debian Wheezy' do
     let(:facts) { {
-      :osfamily        => 'Debian',
-      :operatingsystem => 'Debian',
-      :lsbdistid       => 'Debian',
-      :lsbdistcodename => 'wheezy',
-      :kernelrelease   => '3.12-1-amd64'
+      :osfamily          => 'Debian',
+      :operatingsystem   => 'Debian',
+      :lsbdistid         => 'Debian',
+      :lsbdistcodename   => 'wheezy',
+      :lsbmajdistrelease => '7',
+      :kernelrelease     => '3.2.0-4-amd64'
     } }
 
     it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
@@ -312,10 +313,14 @@ describe 'docker', :type => :class do
     it { should_not contain_package('linux-headers-generic-lts-raring') }
     it { should contain_service('docker').without_provider }
 
+    context 'with defaults' do
+      it { should contain_apt__source('docker') }
+      it { should contain_package('docker').with_name('lxc-docker') }
+    end
+
     context 'with no upstream package source' do
-      let(:params) { {'use_upstream_package_source' => false } }
+      let(:params) { { 'use_upstream_package_source' => false } }
       it { should_not contain_apt__source('docker') }
-      it { should contain_package('docker').with_name('docker.io') }
     end
   end
 

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -312,6 +312,7 @@ describe 'docker', :type => :class do
     context 'with all defaults' do
       it { should compile.with_all_deps }
       it { should contain_class('apt::backports').that_comes_before('Package[linux-image-amd64]') }
+      it { should contain_class('apt::backports').that_comes_before('Package[cgroupfs-mount]') }
       it { should contain_package('linux-image-amd64').with_ensure(/3\.16/) }
       it { should contain_notify('please-reboot') }
       it { should contain_apt__source('docker') }


### PR DESCRIPTION
Prior to this commit, using this module on Debian 7 "Wheezy" with all
of the defaults required manually passing in the package name
(lxc-docker) because the case was not handled in params.pp. The upstream
repo is enabled by default, so I'd suspect that the least surprise to
users would be that the default package name was the same as it is in
the upstream repo: lxc-docker.

This commit modifies params.pp to include better defaults for Debian
Wheezy and modifies the test case accordingly.

For what it's worth, here's how we're using the Docker module at Puppet Labs:

```puppet
  class { '::docker':
    prerequired_packages => ['cgroupfs-mount'],
    package_name         => 'lxc-docker',
    service_name         => 'docker',
    docker_command       => 'docker',
  }
```