### PR TITLE
Issue #93 allow versioning of containers

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -32,6 +32,7 @@ define docker::run(
   $socket_connect = [],
   $hostentries = [],
   $restart = undef,
+  $clean_restart = false,
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command
@@ -111,7 +112,6 @@ define docker::run(
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
     }
-
   } else {
 
     case $::osfamily {
@@ -172,11 +172,17 @@ define docker::run(
       mode    => $mode,
     }
 
+    $restartcmd = $clean_restart ? {
+	    true  => "service docker-${sanitised_title} cleanRestart",
+	    false => undef,
+    }
+
     service { "docker-${sanitised_title}":
       ensure     => $running,
       enable     => true,
       hasstatus  => $hasstatus,
       hasrestart => $hasrestart,
+      restart    => $restartcmd,
       provider   => $provider,
       require    => File[$initscript],
     }

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -173,8 +173,8 @@ define docker::run(
     }
 
     $restartcmd = $clean_restart ? {
-	    true  => "service docker-${sanitised_title} cleanRestart",
-	    false => undef,
+      true  => "service docker-${sanitised_title} cleanRestart",
+      false => undef,
     }
 
     service { "docker-${sanitised_title}":

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -123,6 +123,20 @@ stop() {
     fi
 }
 
+clean() {
+    if ! [ -f $cidfile ]; then
+        failure
+        echo
+        printf "$cidfile does not exist.\n"
+    else
+        cid="$(cat $cidfile)"
+	rm $cidfile
+        $docker rm -f $cid
+        retval=$?
+        return $retval
+    fi
+}
+
 case "$1" in
     start)
     start
@@ -141,11 +155,19 @@ case "$1" in
     stop
     start
     ;;
+    clean)
+    clean
+    ;;
+    cleanRestart)
+    stop
+    clean
+    start
+    ;;
     condrestart)
     [ -f /var/lock/subsys/$prog ] && restart || :
     ;;
     *)
-    echo "Usage: $0 [start|stop|status|reload|restart|probe]"
+    echo "Usage: $0 [start|stop|status|reload|restart|probe|clean|cleanRestart]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
This builds on @bchecketts ' code from https://github.com/garethr/garethr-docker/pull/209, changing the init script and adding a param, clean_restart.
This allows one to change the image tag in docker::run from say redis:2.6 to redis:2.8.14 and have the old container destroyed and a new one running the new image put in its place.