### PR TITLE
Make the debian init script not use the cid if use_name is true

### DIFF
--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -69,6 +69,7 @@ require 'spec_helper'
     context 'when `use_name` is true' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'use_name' => true } }
       it { should contain_file(initscript).with_content(/ --name sample /) }
+      it { should contain_file(initscript).with_content(/docker rm sample/) }
     end
 
     context 'when stopping the service' do

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -58,6 +58,14 @@ fi
 start() {
     [ -x $docker ] || exit 5
 
+    <% if @use_name -%>
+    if [ "true" = "$($docker inspect --format='{{.State.Running}}' <%= @name %>"  ] ; then
+        failure
+        echo
+        printf "Container <%= @name %> is still running.\n"
+        exit 7
+    fi
+    <% else -%>
     if [ -f $cidfile ]; then
         cid="$(cat $cidfile)"
         if [ -n "$cid" ]; then
@@ -73,6 +81,7 @@ start() {
             fi
         fi
     fi
+    <% end -%>
 
     printf "Starting $prog:\t"
     <% if @pull_on_start -%>
@@ -80,6 +89,7 @@ start() {
     <% end -%>
     if [ -f $cidfile ]; then
     <% if @use_name -%>
+        $docker rm <%= @name %> >/dev/null 2>&1
         $docker start <%= @name %>
     <% else -%>
         $docker start $(cat $cidfile)
@@ -93,12 +103,11 @@ start() {
         <% end -%> \
         <%= @image %> \
        <% if @command %> <%= @command %><% end %>
-
     fi
     retval=$?
     echo
     if [ $retval -eq 0 ]; then
-	[ -n "$lockfile" ] && touch $lockfile
+        [ -n "$lockfile" ] && touch $lockfile
         success
     else
         failure
@@ -106,6 +115,10 @@ start() {
 }
 
 stop() {
+    <% if @use_name -%>
+    $docker stop <%= @name %>
+    return $?
+    <% else -%>
     if ! [ -f $cidfile ]; then
         failure
         echo
@@ -121,6 +134,7 @@ stop() {
             return $retval
         fi
     fi
+    <% end -%>
 }
 
 case "$1" in
@@ -131,11 +145,17 @@ case "$1" in
     stop
     ;;
     status)
-        if [ "false" = "$($docker inspect --format='{{.State.Running}}' $(cat $cidfile))"  ] ; then
+    <% if @use_name -%>
+    if [ "false" = "$($docker inspect --format='{{.State.Running}}' <%= @name %>"  ] ; then
+    <% else -%>
+    if [ "false" = "$($docker inspect --format='{{.State.Running}}' $(cat $cidfile))"  ] ; then
+    <% end -%>
         echo $prog not running
         exit 1
+    else
+        echo $prog is running
+        exit 0
     fi
-    $docker inspect $(cat $cidfile)
     ;;
     restart|reload)
     stop


### PR DESCRIPTION
In the systemd init definition in this module, we use the "name" and assume it is the *only* version of that docker container running. We even docker rm as a pre-start.

This change ports that functionality into the general debian init script.

The rationale here is that if we `use_name`, we only ever want one version of the container running ever.

This is especially importance if we have a restart policy on a container. If we ask for `--restart=always`, then docker will restart the container, the cid changes, and this init script is ignorant of that change. (leading to multiple stacked running containers)


This code change makes it safe to use a restart policy, and makes it so --use-name really does make it use the name everywhere (which is always constant) instead of the cid (which can get stale, and is in general flaky)

The good news is: using the name actually makes the output bash version of this script much simpler. If you ever want to ever make the init.d change exactly compatible with the systemd version, we can get rid of all this cid junk entirely. Heck, we already know the "name", it is the name of the puppet resource title. Shouldn't any puppet-run docker always be referenced by name?

cc @mrtyler @EvanKrall 