### PR TITLE
Make the debian init script always use the title as the name of the docker container

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -178,8 +178,9 @@ define docker::run(
     if $initscript == "/etc/init.d/docker-${sanitised_title}" {
       # This exec sequence will ensure the old-style CID container is stopped
       # before we replace the init script with the new-style.
-      exec { "/etc/init.d/docker-${sanitised_title} stop":
-        onlyif => "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid"
+      exec { "/bin/sh /etc/init.d/docker-${sanitised_title} stop":
+        onlyif  => "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid && /usr/bin/test -f /etc/init.d/docker-${sanitised_title}",
+        require => [],
       } ->
       file { "/var/run/docker-${sanitised_title}.cid":
         ensure => absent,

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -24,6 +24,7 @@ require 'spec_helper'
 
     context 'passing the required params' do
       let(:params) { {'command' => 'command', 'image' => 'base'} }
+      it { should compile.with_all_deps }
       it { should contain_service('docker-sample') }
       if (osfamily == 'Debian')
         it { should contain_service('docker-sample').with_hasrestart('false') }

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -115,12 +115,12 @@ case "$1" in
     stop
     ;;
     status)
-    if [ "false" = "$($docker inspect --format='{{.State.Running}}' <%= @sanitised_title %>)" ]; then
-        echo $prog not running
-        exit 1
-    else
+    if [ "true" = "$($docker inspect --format='{{.State.Running}}' <%= @sanitised_title %>)" ]; then
         echo $prog is running
         exit 0
+    else
+        echo $prog not running
+        exit 1
     fi
     ;;
     restart|reload)

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -48,7 +48,6 @@ fi
 HOME=/root/
 docker="/usr/bin/<%= @docker_command %>"
 prog="docker-<%= @sanitised_title %>"
-cidfile="/var/run/$prog.cid"
 if [ -d /var/lock/subsys ]; then
     lockfile="/var/lock/subsys/$prog"
 else
@@ -58,47 +57,29 @@ fi
 start() {
     [ -x $docker ] || exit 5
 
-    if [ -f $cidfile ]; then
-        cid="$(cat $cidfile)"
-        if [ -n "$cid" ]; then
-            $docker ps --no-trunc=true|grep $cid
-            retval=$?
-            if [ $retval -eq 0 ]; then
-                failure
-                echo
-                printf "Container $cid is still running.\n"
-                exit 7
-            else
-                rm -f $lockfile
-            fi
-        fi
+    if [ "true" = "$($docker inspect --format='{{.State.Running}}' <%= @sanitised_title %>)" ]; then
+       failure
+       printf "Container <%= @sanitised_title %> is still running.\n"
+       exit 7
     fi
 
     printf "Starting $prog:\t"
+    $docker rm <%= @sanitised_title %> >/dev/null 2>&1
     <% if @pull_on_start -%>
         $docker pull <%= @image %>
     <% end -%>
-    if [ -f $cidfile ]; then
-    <% if @use_name -%>
-        $docker start <%= @name %>
-    <% else -%>
-        $docker start $(cat $cidfile)
-    <% end -%>
-    else
-        $docker run --cidfile=$cidfile \
-        <%= @docker_run_flags %> \
-        <% if @use_name %>--name <%= @name %><% end %> \
-        <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
-            <%= param %> <% end %> \
-        <% end -%> \
-        <%= @image %> \
-       <% if @command %> <%= @command %><% end %>
+    $docker run \
+    <%= @docker_run_flags %> \
+    --name <%= @sanitised_title %> \
+    <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
+        <%= param %> <% end %> \
+    <% end -%> \
+    <%= @image %> \
+    <% if @command %> <%= @command %><% end %>
 
-    fi
     retval=$?
     echo
     if [ $retval -eq 0 ]; then
-	[ -n "$lockfile" ] && touch $lockfile
         success
     else
         failure
@@ -106,21 +87,10 @@ start() {
 }
 
 stop() {
-    if ! [ -f $cidfile ]; then
-        failure
-        echo
-        printf "$cidfile does not exist.\n"
-        exit 7
-    else
-        cid="$(cat $cidfile)"
-        if [ -n $cid ]; then
-            echo -n $"Stopping $prog: "
-            $docker stop $(cat $cidfile)
-            retval=$?
-            [ $retval -eq 0 ] && rm -f $lockfile
-            return $retval
-        fi
-    fi
+    echo -n "Stopping $prog: "
+    $docker stop <%= @sanitised_title %>
+    $docker rm <%= @sanitised_title %>
+    return $?
 }
 
 case "$1" in
@@ -131,11 +101,13 @@ case "$1" in
     stop
     ;;
     status)
-        if [ "false" = "$($docker inspect --format='{{.State.Running}}' $(cat $cidfile))"  ] ; then
+    if [ "false" = "$($docker inspect --format='{{.State.Running}}' <%= @sanitised_title %>)" ]; then
         echo $prog not running
         exit 1
+    else
+        echo $prog is running
+        exit 0
     fi
-    $docker inspect $(cat $cidfile)
     ;;
     restart|reload)
     stop


### PR DESCRIPTION
We already have a name for the docker::run, it is the title.

This PR makes all docker::run's use the title as the primary key, instead of the cid file.

This greatly simplifies the (debian) init script, makes it compatible with restart policies, and makes it much more obvious to the user when they run docker-ps themselves. (and don't have to remember to cleanup cid files if they manually kill something)

Obsoletes #190
Related to #209, #203