### PR TITLE
Remove unused references to use_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ docker::run { 'helloworld':
 }
 ```
 
-This is equivalent to running the following under upstart:
+This is equivalent to running the following:
 
-    docker run -d base /bin/sh -c "while true; do echo hello world; sleep 1; done"
+    docker run -d base --name helloworld /bin/sh -c "while true; do echo hello world; sleep 1; done"
 
 Run also contains a number of optional parameters:
 
@@ -200,7 +200,6 @@ docker::run { 'helloworld':
   ports           => ['4444', '4555'],
   expose          => ['4666', '4777'],
   links           => ['mysql:db'],
-  use_name        => true,
   volumes         => ['/var/lib/couchdb', '/var/log'],
   volumes_from    => '6446ea52fbc9',
   memory_limit    => 10m, # (format: <number><unit>, where unit = b, k, m or g)
@@ -222,7 +221,7 @@ Specifying `pull_on_start` will pull the image before each time it is started.
 
 The `depends` option allows expressing containers that must be started before. This affects the generation of the init.d/systemd script.
 
-The service file created for systemd and upstart based systems enables automatic restarting of the service on failure by default.
+The service file created for systemd based systems enables automatic restarting of the service on failure by default.
 
 To use an image tag just append the tag name to the image name separated by a semicolon:
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -11,7 +11,6 @@ define docker::run(
   $expose = [],
   $volumes = [],
   $links = [],
-  $use_name = false,
   $running = true,
   $volumes_from = [],
   $net = 'bridge',

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -37,7 +37,6 @@ describe 'docker class' do
         }
         docker::run { 'nginx3':
           image   => 'nginx',
-          use_name => true,
           require => Docker::Image['nginx'],
         }
     "}

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -28,6 +28,7 @@ require 'spec_helper'
       it { should contain_service('docker-sample') }
       if (osfamily == 'Debian')
         it { should contain_service('docker-sample').with_hasrestart('false') }
+        it { should contain_file(initscript).with_content(/ --name sample /) }
         it { should contain_file(initscript).with_content(/\$docker run/) }
         it { should contain_file(initscript).with_content(/#{command}/) }
       else
@@ -65,11 +66,6 @@ require 'spec_helper'
     context 'when lxc_conf disables swap' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'lxc_conf' => 'lxc.cgroup.memory.memsw.limit_in_bytes=536870912'} }
       it { should contain_file(initscript).with_content(/-lxc-conf=\"lxc.cgroup.memory.memsw.limit_in_bytes=536870912\"/) }
-    end
-
-    context 'when `use_name` is true' do
-      let(:params) { {'command' => 'command', 'image' => 'base', 'use_name' => true } }
-      it { should contain_file(initscript).with_content(/ --name sample /) }
     end
 
     context 'when stopping the service' do


### PR DESCRIPTION
The removes all references to use_name.
Notably absent here is changes to the systemd script, which never used this parameter in the first place.
The normal init script matches this behavior, so this parameter is cruft.
