### PR TITLE
Removed upstart transition code for docker::run

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -1,6 +1,6 @@
 # == Define: docker:run
 #
-# A define which manages an upstart managed docker container
+# A define which managed docker container
 #
 define docker::run(
   $image,
@@ -96,11 +96,6 @@ define docker::run(
   $sanitised_title = regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G')
   $sanitised_depends_array = regsubst($depends_array, '[^0-9A-Za-z.\-]', '-', 'G')
 
-  $provider = $::operatingsystem ? {
-    'Ubuntu' => 'upstart',
-    default  => undef,
-  }
-
   if $restart {
 
     $cidfile = "/var/run/docker-${sanitised_title}.cid"
@@ -122,18 +117,6 @@ define docker::run(
         $hasrestart = false
         $uses_systemd = false
         $mode = '0755'
-
-        # When switching between styles of init scripts (e.g. upstart and sysvinit),
-        # we want to stop the service using the old init script. Since `service` will
-        # prefer a sysvinit style script over an upstart one if both exist, we need
-        # to stop the service before adding the sysvinit script.
-        exec { "/usr/sbin/service docker-${sanitised_title} stop":
-          onlyif  => "/usr/bin/test -f ${deprecated_initscript}"
-        } ->
-        file { $deprecated_initscript:
-          ensure => absent
-        } ->
-        File[$initscript]
       }
       'RedHat': {
         if versioncmp($::operatingsystemrelease, '7.0') < 0 {
@@ -193,7 +176,6 @@ define docker::run(
       enable     => true,
       hasstatus  => $hasstatus,
       hasrestart => $hasrestart,
-      provider   => $provider,
       require    => File[$initscript],
     }
 


### PR DESCRIPTION
This code served us well when we were transitioning from upstart-controlled.

However, now it kinda hurts us when containers misbehave, especially with the CID->Name transition.

This is because when users have code like this:

```puppet
docker::image { 'foo': } ~>
docker::run { 'foo': }
```

Both transition mechanisms act, as both execs are "refreshed". This can cause additional red and in some cases at Yelp, caused puppet runs to not converge. (because the stop failed, causing the next resource, the init script, to never get replaced)

I think it will be best to only have one kind of backwards compatible transition code in place at a time.