### PR TITLE
Added docs explaining what the restart parameter on docker::run really does

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -1,6 +1,27 @@
 # == Define: docker:run
 #
-# A define which managed docker container
+# A define which manages a running docker container.
+#
+# == Parameters
+#
+# [*restart*]
+# Sets a restart policy on the docker run.
+# Note: If set, puppet will NOT setup an init script to manage, instead
+# it will do a raw docker run command using a CID file to track the container 
+# ID.
+#
+# If you want a normal named container with an init script and a restart policy
+# you must use the extra_parameters feature and pass it in like this:
+#
+#    extra_parameters => ['--restart=always']
+#
+# This will allow the docker container to be restarted if it dies, without
+# puppet help.
+#
+# [*extra_parameters*]
+# An array of additional command line arguments to pass to the `docker run`
+# command. Useful for adding additional new or experimental options that the
+# module does not yet support.
 #
 define docker::run(
   $image,


### PR DESCRIPTION
While I personally think that the way that `restart` does things is ill-advised, I understand that some people want it to work like this.

This adds docs to help other people know how they can get a restart policy and have puppet continue to manage the container via the normal init script mechanism.