### PR TITLE
Removed the hasrestart parameter on docker::run init script stuf

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -135,7 +135,6 @@ define docker::run(
         $init_template = 'docker/etc/init.d/docker-run.erb'
         $deprecated_initscript = "/etc/init/docker-${sanitised_title}.conf"
         $hasstatus  = true
-        $hasrestart = false
         $uses_systemd = false
         $mode = '0755'
       }
@@ -144,14 +143,12 @@ define docker::run(
           $initscript     = "/etc/init.d/docker-${sanitised_title}"
           $init_template  = 'docker/etc/init.d/docker-run.erb'
           $hasstatus      = undef
-          $hasrestart     = undef
           $mode           = '0755'
           $uses_systemd   = false
         } else {
           $initscript     = "/etc/systemd/system/docker-${sanitised_title}.service"
           $init_template  = 'docker/etc/systemd/system/docker-run.erb'
           $hasstatus      = true
-          $hasrestart     = true
           $mode           = '0644'
           $uses_systemd   = true
         }
@@ -160,7 +157,6 @@ define docker::run(
         $initscript     = "/etc/systemd/system/docker-${sanitised_title}.service"
         $init_template  = 'docker/etc/systemd/system/docker-run.erb'
         $hasstatus      = true
-        $hasrestart     = true
         $mode           = '0644'
         $uses_systemd   = true
       }
@@ -193,11 +189,10 @@ define docker::run(
     }
 
     service { "docker-${sanitised_title}":
-      ensure     => $running,
-      enable     => true,
-      hasstatus  => $hasstatus,
-      hasrestart => $hasrestart,
-      require    => File[$initscript],
+      ensure    => $running,
+      enable    => true,
+      hasstatus => $hasstatus,
+      require   => File[$initscript],
     }
 
     if $uses_systemd {

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -27,7 +27,6 @@ require 'spec_helper'
       it { should compile.with_all_deps }
       it { should contain_service('docker-sample') }
       if (osfamily == 'Debian')
-        it { should contain_service('docker-sample').with_hasrestart('false') }
         it { should contain_file(initscript).with_content(/\$docker run/) }
         it { should contain_file(initscript).with_content(/#{command}/) }
       else


### PR DESCRIPTION
All docker-run init scripts has a restart functions, this is no longer needed and simplifies the code.