### PR TITLE
adding support for Amazon Linux in run.pp

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -139,7 +139,7 @@ define docker::run(
         $mode = '0755'
       }
       'RedHat': {
-        if ($::operatingsystem == "Amazon") or (versioncmp($::operatingsystemrelease, '7.0') < 0) {
+        if ($::operatingsystem == 'Amazon') or (versioncmp($::operatingsystemrelease, '7.0') < 0) {
           $initscript     = "/etc/init.d/docker-${sanitised_title}"
           $init_template  = 'docker/etc/init.d/docker-run.erb'
           $hasstatus      = undef

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -139,7 +139,7 @@ define docker::run(
         $mode = '0755'
       }
       'RedHat': {
-        if versioncmp($::operatingsystemrelease, '7.0') < 0 {
+        if ($::operatingsystem == "Amazon") or (versioncmp($::operatingsystemrelease, '7.0') < 0) {
           $initscript     = "/etc/init.d/docker-${sanitised_title}"
           $init_template  = 'docker/etc/init.d/docker-run.erb'
           $hasstatus      = undef


### PR DESCRIPTION
$operatingsystemrelease has "20XX.XX" format on Amazon Linux boxes, which is obviously greater then 7.0, but Amazon Linux is still on SysVinit.
