### PR TITLE
Reduced the APT Key to 8 chars to pass validation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,7 @@ class docker::install {
           release           => 'docker',
           repos             => 'main',
           required_packages => 'debian-keyring debian-archive-keyring',
-          key               => '36A1D7869245C8950F966E92D8576A8BA88D21E9',
+          key               => '36A1D71E',
           key_source        => 'https://get.docker.io/gpg',
           pin               => '10',
           include_src       => false,


### PR DESCRIPTION
On Ubuntu 14.04 LTS using the module with version 4.0.2 I get : 

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: validate_re(): "36A1D7869245C8950F966E92D8576A8BA88D21E9" does not match ["\\A(0x)?[0-9a-fA-F]{8}\\Z", "\\A(0x)?[0-9a-fA-F]{16}\\Z"] at /etc/puppet/modules/apt/manifests/key.pp:60 on node mma01
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

It seems the key is validated on 8 or 16 chars by the APT module. I simply reduced the key in the install class to meet this requirements