### PR TITLE
Quote credentials in 'docker login' exec

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -38,7 +38,7 @@ define docker::registry(
 
   if $ensure == 'present' {
     if $username != undef and $password != undef and $email != undef {
-      $auth_cmd = "${docker_command} login -u ${username} -p ${password} -e ${email} ${server}"
+      $auth_cmd = "${docker_command} login -u '${username}' -p '${password}' -e '${email}' ${server}"
     }
     else {
       $auth_cmd = "${docker_command} login ${server}"

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -31,12 +31,12 @@ describe 'docker::registry', :type => :define do
 
   context 'with ensure => present and username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker login -u user1 -p secret -e user1@example.io localhost:5000') }
+    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000") }
   end
 
   context 'with username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker login -u user1 -p secret -e user1@example.io localhost:5000') }
+    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000") }
   end
 
   context 'with an invalid ensure value' do


### PR DESCRIPTION
If your password (or any other field) contains characters which require escaping the `docker login` exec will fail.