### PR TITLE
make repo_opt customizable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,8 +140,11 @@
 #   Default is set on a per system basis in docker::params
 #
 # [*docker_users*]
-#   Specifc a array of users to add to the docker group
+#   Specify an array of users to add to the docker group
 #   Default is empty
+#
+# [*repo_opt*]
+#   Specify a string to pass as repository options (RedHat only)
 #
 class docker(
   $version                     = $docker::params::version,
@@ -182,6 +185,7 @@ class docker(
   $service_name                = $docker::params::service_name,
   $docker_command              = $docker::params::docker_command,
   $docker_users                = [],
+  $repo_opt                    = $docker::params::repo_opt,
 ) inherits docker::params {
 
   validate_string($version)


### PR DESCRIPTION
The "repo_opt" option that is automatically determined in params.pp works on normal RHEL7, but not on RHEL7 that is joined and controlled by a Satellite installation.  The repository names there are different than the stock RHEL7 ones.  Therefore, this pull request will keep the default normally, but allows someone to override by setting it manually.

Plus minor spelling correction...