### PR TITLE
changed docker::{image, registry, run} to use docker::command and doc…

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -30,7 +30,7 @@ define docker::image(
   $docker_tar = undef,
 ) {
   include docker::params
-  $docker_command = $docker::params::docker_command
+  $docker_command = $docker::docker_command
   validate_re($ensure, '^(present|absent|latest)$')
   validate_re($image, '^[\S]*$')
   validate_bool($force)

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -34,7 +34,7 @@ define docker::registry(
 
   validate_re($ensure, '^(present|absent)$')
 
-  $docker_command = $docker::params::docker_command
+  $docker_command = $docker::docker_command
 
   if $ensure == 'present' {
     if $username != undef and $password != undef and $email != undef {

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -56,8 +56,8 @@ define docker::run(
   $restart = undef,
 ) {
   include docker::params
-  $docker_command = $docker::params::docker_command
-  $service_name = $docker::params::service_name
+  $docker_command = $docker::docker_command
+  $service_name = $docker::service_name
 
   validate_re($image, '^[\S]*$')
   validate_re($title, '^[\S]*$')


### PR DESCRIPTION
…ker::service_name instead of docker::params::command and docker::params::service_name.

This is done in order to make it possible to override the command and service_name and make it possible to install and run lxc-docker on debian instead of docker.io