### PR TITLE
Remove exports from rhel7 sysconfig

### DIFF
--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -364,6 +364,11 @@ describe 'docker', :type => :class do
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=rhel7-extras') }
 
+    let(:params) { {'proxy' => 'http://127.0.0.1:3128' } }
+    service_config_file = '/etc/sysconfig/docker'
+    it { should contain_file(service_config_file).with_content(/^http_proxy='http:\/\/127.0.0.1:3128'/) }
+    it { should contain_file(service_config_file).with_content(/^  https_proxy='http:\/\/127.0.0.1:3128'/) }
+
   end
 
   context 'specific to Oracle Linux 7 or above' do

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -13,8 +13,8 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 <% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>"
 
-<% if @proxy %>export http_proxy='<%= @proxy %>'
-  export https_proxy='<%= @proxy %>'<% end %>
-<% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>
+<% if @proxy %>http_proxy='<%= @proxy %>'
+  https_proxy='<%= @proxy %>'<% end %>
+<% if @no_proxy %>no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
-# export TMPDIR="<%= @tmp_dir %>"
+# TMPDIR="<%= @tmp_dir %>"


### PR DESCRIPTION
systemd does not execute files provided by the EnvironmentFile option in
the unit file and instead expects them to be a simple set of variable
assignments. This means that export commands are ignored. Replacing them
with variable assignment fixes the issue.

This should resolve #244 and covers #259 as well