### PR TITLE
Fix docker service template

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -7,7 +7,6 @@ After=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><
 Requires=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " docker-#{d}.service" %><% end %><% end %>
 
 [Service]
-<%- if @username -%>User=<%= @username %><%- end -%>
 Restart=on-failure
 StartLimitInterval=20
 StartLimitBurst=5


### PR DESCRIPTION
I don't believe the service User should be changed when you try to run the container as a certain user.

For example I want the jenkins container to run as the jenkins user. However when I pass username to run.pp this template also attempts to change the "Service" user to jenkins:

User=jenkins

I nuked that like in the template.