### PR TITLE
Clean up older docker images left behind

### DIFF
--- a/manifests/cleanup.pp
+++ b/manifests/cleanup.pp
@@ -1,0 +1,20 @@
+#
+#   Colin Wood <cwood@atlassian.com>
+#   10-06-15
+#
+#   Clean up old docker images safely that have been removed.
+#
+class docker::cleanup {
+  cron { 'docker rm':
+    user    => 'root',
+    command => 'docker rm $(docker ps --filter status=exited -q 2>/dev/null) 2>/dev/null',
+    minute  => $docker::docker_cleanup_minute,
+    hour    => $docker::docker_cleanup_hour,
+  }
+  cron { 'docker rmi':
+    user    => 'root',
+    command => 'docker rmi $(docker images --filter dangling=true -q 2>/dev/null) 2>/dev/null',
+    minute  => $docker::docker_cleanup_minute,
+    hour    => $docker::docker_cleanup_hour,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,6 +146,15 @@
 # [*repo_opt*]
 #   Specify a string to pass as repository options (RedHat only)
 #
+# [*docker_cleanup*]
+#   Clean up older docker images that are good to remove.
+#
+# [*docker_cleanup_minute*]
+#   Specify the cron minute used to clean up older docker images
+#
+# [*docker_cleanup_hour*]
+#   Specify the cron hour to clean up older docker images
+#
 class docker(
   $version                     = $docker::params::version,
   $ensure                      = $docker::params::ensure,
@@ -184,14 +193,17 @@ class docker(
   $package_name                = $docker::params::package_name,
   $service_name                = $docker::params::service_name,
   $docker_command              = $docker::params::docker_command,
-  $docker_users                = [],
   $repo_opt                    = $docker::params::repo_opt,
+  $docker_cleanup              = $docker::params::docker_cleanup,
+  $docker_cleanup_minute       = $docker::params::docker_cleanup_minute,
+  $docker_cleanup_hour         = $docker::params::docker_cleanup_hour,
 ) inherits docker::params {
 
   validate_string($version)
   validate_re($::osfamily, '^(Debian|RedHat|Archlinux)$', 'This module only works on Debian and Red Hat based systems.')
   validate_bool($manage_kernel)
   validate_bool($manage_package)
+  validate_bool($docker_cleanup)
   validate_array($docker_users)
 
   if $log_level {
@@ -224,6 +236,10 @@ class docker(
   contain 'docker::install'
   contain 'docker::config'
   contain 'docker::service'
+
+  if $docker_cleanup{
+    class{'docker::cleanup': }
+  }
 
   # Only bother trying extra docker stuff after docker has been installed,
   # and is running.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,6 +194,7 @@ class docker(
   $service_name                = $docker::params::service_name,
   $docker_command              = $docker::params::docker_command,
   $repo_opt                    = $docker::params::repo_opt,
+  $docker_users                = $docker::params::docker_users,
   $docker_cleanup              = $docker::params::docker_cleanup,
   $docker_cleanup_minute       = $docker::params::docker_cleanup_minute,
   $docker_cleanup_hour         = $docker::params::docker_cleanup_hour,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,9 @@ class docker::params {
   $service_name_default         = 'docker'
   $docker_command_default       = 'docker'
   $docker_group_default         = 'docker'
+  $docker_cleanup               = false,
+  $docker_cleanup_minute        = '0'
+  $docker_cleanup_hour          = '1'
   case $::osfamily {
     'Debian' : {
       case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,8 @@ class docker::params {
   $service_name_default         = 'docker'
   $docker_command_default       = 'docker'
   $docker_group_default         = 'docker'
-  $docker_cleanup               = false,
+  $docker_users                 = []
+  $docker_cleanup               = false
   $docker_cleanup_minute        = '0'
   $docker_cleanup_hour          = '1'
   case $::osfamily {

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -15,6 +15,6 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 
 <% if @proxy %>http_proxy='<%= @proxy %>'
 https_proxy='<%= @proxy %>'<% end %>
-<% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>
+<% if @no_proxy %>no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
 # export TMPDIR="<%= @tmp_dir %>"

--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -13,8 +13,8 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 <% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>"
 
-<% if @proxy %>export http_proxy='<%= @proxy %>'
-  export https_proxy='<%= @proxy %>'<% end %>
+<% if @proxy %>http_proxy='<%= @proxy %>'
+https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
 # export TMPDIR="<%= @tmp_dir %>"


### PR DESCRIPTION
On pulling new images we will need to clean up the older ones. This is a PR that makes a cron that runs every day at 1am and removes docker images safely.