### PR TITLE
Exported home path in the init.d template file

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -18,7 +18,7 @@
 #   If you want to add a docker image from specific docker file
 #
 # [*docker_tar*]
-#   If you want to load a docker image from specific docker tar 
+#   If you want to load a docker image from specific docker tar
 #
 define docker::image(
   $ensure    = 'present',

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -7,7 +7,7 @@
 # [*restart*]
 # Sets a restart policy on the docker run.
 # Note: If set, puppet will NOT setup an init script to manage, instead
-# it will do a raw docker run command using a CID file to track the container 
+# it will do a raw docker run command using a CID file to track the container
 # ID.
 #
 # If you want a normal named container with an init script and a restart policy

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -45,7 +45,7 @@ else
     }
 fi
 
-HOME=/root/
+export HOME=/root/
 docker="/usr/bin/<%= @docker_command %>"
 prog="docker-<%= @sanitised_title %>"
 if [ -d /var/lock/subsys ]; then


### PR DESCRIPTION
Fix for using the module with Puppet on a Centos machine
The /sbin/service doesn't retain the home variable
