### PR TITLE
Switch to using >= 2.0.0 for Apt module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
-      ref: 1.8.0
+      ref: 2.0.1
     stdlib: git://github.com/puppetlabs/puppetlabs-stdlib.git
     epel: git://github.com/stahnma/puppet-module-epel.git
   symlinks:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,15 +20,19 @@ class docker::install {
 
       if ($docker::use_upstream_package_source) {
         include apt
+        package { ['debian-keyring', 'debian-archive-keyring']:
+          ensure => present,
+          before => Apt::Source['docker'],
+        }
         apt::source { 'docker':
-          location          => $docker::package_source_location,
-          release           => 'docker',
-          repos             => 'main',
-          required_packages => 'debian-keyring debian-archive-keyring',
-          key               => '36A1D7869245C8950F966E92D8576A8BA88D21E9',
-          key_source        => 'https://get.docker.io/gpg',
-          pin               => '10',
-          include_src       => false,
+          location => $docker::package_source_location,
+          release  => 'docker',
+          repos    => 'main',
+          pin      => '10',
+          key      => {
+            'id'     => '36A1D7869245C8950F966E92D8576A8BA88D21E9',
+            'source' => 'https://get.docker.io/gpg',
+          },
         }
         if $docker::manage_package {
           Apt::Source['docker'] -> Package['docker']

--- a/metadata.json
+++ b/metadata.json
@@ -50,7 +50,7 @@
       "version_requirement": ">= 4.1.0"
     },{
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.1.0 <= 1.8.0"
+      "version_requirement": ">= 2.0.1"
     },{
       "name": "stahnma/epel",
       "version_requirement": ">= 0.0.6"

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -19,6 +19,8 @@ describe 'docker', :type => :class do
         it { should contain_service('docker').with_hasrestart('false') }
         it { should contain_class('apt') }
         it { should contain_package('apt-transport-https').that_comes_before('Package[docker]') }
+        it { should contain_package('debian-keyring').that_comes_before('Apt::Source[docker]') }
+        it { should contain_package('debian-archive-keyring').that_comes_before('Apt::Source[docker]') }
         it { should contain_package('docker').with_name('lxc-docker').with_ensure('present') }
         it { should contain_apt__source('docker').with_location('https://get.docker.io/ubuntu') }
         it { should contain_file('/etc/init.d/docker').with_ensure('link').with_target('/lib/init/upstart-job') }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -26,7 +26,7 @@ RSpec.configure do |c|
     puppet_module_install(:source => proj_root, :module_name => 'docker')
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
-      on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '1.8.0'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '2.0.1'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'stahnma-epel'), { :acceptable_exit_codes => [0,1] }
     end
   end


### PR DESCRIPTION
This updates Apt::Source to be compatible with the new version of the Puppet Labs Apt module. I hope this doesn't break stop anyone else from upgrading this module!