### PR TITLE
Fix discrepancy between docker run and docker exec

### DIFF
--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -8,6 +8,7 @@ define docker::exec(
   $tty = false,
   $container = undef,
   $command = undef,
+  $sanitise_name = true,
 ) {
   include docker::params
 
@@ -26,7 +27,13 @@ define docker::exec(
     tty => $tty,
   })
 
-  $exec = "${docker_command} exec ${docker_exec_flags} ${container} ${command}"
+
+  if $sanitise_name {
+    $sanitised_container = regsubst($container, '[^0-9A-Za-z.\-]', '-', 'G')
+  } else {
+    $sanitised_container = $container
+  }
+  $exec = "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${command}"
 
   exec { $exec:
     environment => 'HOME=/root',


### PR DESCRIPTION
When you run a container, its name is sanitized. When you however
perform some docker exec on it later, the name is NOT sanitized.

Eg.:

```puppet
docker::run { 'my_container':
	..
}

docker::exec { 'stop_my_container':
	$container => 'my_container',
	...
}
```

The container from `docker::run` will be renamed to `my-container`; the
oen from the `docker::exec` will _not_ be renamed. This may be perceived
as weird behaviour. This is particularly annoying when your container
name is passed via some variable.

Therefore, I implemented a parameter for
`docker::exec`, `$sanitize_name`, which defaults to true. If true, the name
will be sanitized according to the same rules as for `docker::run`.