### PR TITLE
(MAINT) fixes acceptance tests to test against command instead of image

### DIFF
--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -69,7 +69,7 @@ describe 'docker class' do
 
     describe command("#{command} ps -l --no-trunc=true"), :sudo => true do
       its(:exit_status) { should eq 0 }
-      its(:stdout) { should match /nginx\:/ }
+      its(:stdout) { should match /nginx -g 'daemon off;'/ }
     end
 
     describe command("#{command} ps"), :sudo => true do
@@ -83,7 +83,7 @@ describe 'docker class' do
 
     describe command("#{command} ps --no-trunc | grep `cat /var/run/docker-nginx2.cid`"), :sudo => true do
       its(:exit_status) { should eq 0 }
-      its(:stdout) { should match /nginx\:/ }
+      its(:stdout) { should match /nginx -g 'daemon off;'/ }
     end
 
     describe command('netstat -tlndp') do


### PR DESCRIPTION
Due to the upgrade of docker from 1.6->1.7 the text returned from
`docker ps -1 --no-trunc` no longer displays the image as `nginx:latest`.
For future proofing these tests, it's better to expect the command instead
of the image anyway.