### PR TITLE
(MAINT) Adds beaker/puppet_install_helper gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,20 @@ rvm:
   - 2.2
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 3.6.0"
-  - PUPPET_VERSION="~> 3.7.0"
-  - PUPPET_VERSION="~> 3.8.0"
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 4.1.0"
+  - PUPPET_GEM_VERSION="~> 3.6.0"
+  - PUPPET_GEM_VERSION="~> 3.7.0"
+  - PUPPET_GEM_VERSION="~> 3.8.0"
+  - PUPPET_GEM_VERSION="~> 4.0.0"
+  - PUPPET_GEM_VERSION="~> 4.1.0"
 matrix:
   exclude:
     - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 4.0.0"
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
     - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 4.1.0"
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
     - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.6.0"
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
     - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.7.0"
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
     - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.8.0"
+      env: PUPPET_GEM_VERSION="~> 3.8.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ By default the tests use a baseline version of Puppet.
 If you have Ruby 2.x or want a specific version of Puppet,
 you must set an environment variable such as:
 
-    export PUPPET_VERSION="~> 3.2.0"
+    export PUPPET_GEM_VERSION="~> 3.2.0"
 
 Install the dependencies like so...
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
   gem "puppet-lint"
   gem "puppet-lint-unquoted_string-check"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
@@ -16,6 +16,7 @@ group :development do
   gem "travis"
   gem "travis-lint"
   gem "beaker", :git => 'https://github.com/puppetlabs/beaker.git'
+  gem "beaker-puppet_install_helper", :require => false
   gem "beaker-rspec"
   gem "puppet-blacksmith"
   gem "guard-rake"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,17 +1,9 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
 require 'pry'
 
-unless ENV['BEAKER_provision'] == 'no'
-  hosts.each do |host|
-    # Install Puppet
-    if host.is_pe?
-      install_pe
-    else
-      install_puppet
-    end
-  end
-end
+run_puppet_install_helper
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
This will allow the module to be easily tested by Puppet jenkins ci,
and facilitates testing with foss, pe, and agent environments.