### PR TITLE
Change installation URL from get.docker.io to get.docker.com

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@
 #
 # [*package_source_location*]
 #   If you're using an upstream package source, what is it's
-#   location. Defaults to https://get.docker.io/ubuntu on Debian
+#   location. Defaults to https://get.docker.com/ubuntu on Debian
 #
 # [*service_state*]
 #   Whether you want to docker daemon to start up

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,7 +26,7 @@ class docker::install {
           repos             => 'main',
           required_packages => 'debian-keyring debian-archive-keyring',
           key               => '36A1D7869245C8950F966E92D8576A8BA88D21E9',
-          key_source        => 'https://get.docker.io/gpg',
+          key_source        => 'https://get.docker.com/gpg',
           pin               => '10',
           include_src       => false,
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class docker::params {
         }
       }
       $docker_group = $docker_group_default
-      $package_source_location     = 'https://get.docker.io/ubuntu'
+      $package_source_location     = 'https://get.docker.com/ubuntu'
       $use_upstream_package_source = true
       $detach_service_in_init = true
       $repo_opt = undef

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -20,7 +20,7 @@ describe 'docker', :type => :class do
         it { should contain_class('apt') }
         it { should contain_package('apt-transport-https').that_comes_before('Package[docker]') }
         it { should contain_package('docker').with_name('lxc-docker').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('https://get.docker.io/ubuntu') }
+        it { should contain_apt__source('docker').with_location('https://get.docker.com/ubuntu') }
         it { should contain_file('/etc/init.d/docker').with_ensure('link').with_target('/lib/init/upstart-job') }
         it { should contain_package('docker').with_install_options(nil) }
 


### PR DESCRIPTION
On Ubuntu I have to use get.docker.com/ubuntu in the apt source to get the latest version. Using docker.io tells me that 1.5 is latest instead of 1.7 as expected.