### PR TITLE
Support installing from RPM url on RedHat based systems. Fixes #277

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ class { 'docker':
 }
 ```
 
+And if you want to install a specific rpm package of docker you can do so:
+
+```puppet
+class { 'docker' :
+  manage_package              => true,
+  use_upstream_package_source => false,
+  package_name                => 'docker-engine'
+  package_source              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+  prerequired_packages        => [ 'glibc.i686', 'glibc.x86_64', 'sqlite.i686', 'sqlite.x86_64', 'device-mapper', 'device-mapper-libs', 'device-mapper-event-libs', 'device-mapper-event' ]
+}
+```
+
 And if you want to track the latest version you can do so:
 
 ```puppet
@@ -339,4 +351,3 @@ docker::exec { 'cron_allow_root':
   unless       => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
 }
 ```
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,6 +279,7 @@ class docker(
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
   $execdriver                        = $docker::params::execdriver,
   $manage_package                    = $docker::params::manage_package,
+  $package_source                    = $docker::params::package_source,
   $manage_epel                       = $docker::params::manage_epel,
   $package_name                      = $docker::params::package_name,
   $service_name                      = $docker::params::service_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -67,17 +67,38 @@ class docker::install {
   }
 
   if $docker::manage_package {
+
     if $docker::repo_opt {
-      package { 'docker':
+      $docker_hash = { 'install_options' => $docker::repo_opt }
+    } else {
+      $docker_hash = {}
+    }
+
+    if $docker::package_source {
+      case $::osfamily {
+        'Debian' : {
+          $pk_provider = 'dpkg'
+        }
+        'RedHat' : {
+          $pk_provider = 'rpm'
+        }
+        default : {
+          $pk_provider = undef
+        }
+      }
+
+      ensure_resource('package', 'docker', merge($docker_hash, {
+        ensure          => $ensure,
+        provider        => $pk_provider,
+        source          => $docker::package_source,
+        name            => $docker::package_name,
+      }))
+
+    } else {
+      ensure_resource('package', 'docker', merge($docker_hash, {
         ensure          => $ensure,
         name            => $docker::package_name,
-        install_options => $docker::repo_opt,
-      }
-    } else {
-        package { 'docker':
-          ensure => $ensure,
-          name   => $docker::package_name,
-        }
+      }))
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class docker::params {
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
   $manage_package                    = true
+  $package_source                    = undef
   $manage_kernel                     = true
   $package_name_default              = 'docker-engine'
   $service_name_default              = 'docker'

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -124,6 +124,40 @@ describe 'docker', :type => :class do
           it { should contain_package('device-mapper').with_ensure('present') }
         end
 
+        context 'It should install from rpm package' do
+          let(:params) { {
+            'manage_package'              => true,
+            'use_upstream_package_source' => false,
+            'package_name'                => 'docker-engine',
+            'package_source'              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm'
+          } }
+          it do
+            should contain_package('docker').with(
+              'ensure' => 'present',
+              'source' => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+              'name'   => 'docker-engine'
+            )
+          end
+        end
+
+        context 'It should install from rpm package with docker::repo_opt set' do
+          let(:params) { {
+            'manage_package'              => true,
+            'use_upstream_package_source' => false,
+            'package_name'                => 'docker-engine',
+            'package_source'              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+            'repo_opt'                    => '--enablerepo=rhel7-extras'
+          } }
+          it do
+            should contain_package('docker').with(
+              'ensure'          => 'present',
+              'source'          => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+              'name'            => 'docker-engine',
+              'install_options' => '--enablerepo=rhel7-extras'
+            )
+          end
+        end
+
       end
 
       if osfamily == 'Archlinux'


### PR DESCRIPTION
On Centos 6.x at least, the docker upstream version is maxed out at 1.5 . This pr allows to install custom rpm packages from docker.io (1.6, 1.7) on Centos based systems. It fixes #277 .
ping @garethr 