### PR TITLE
extra_parameter do not work when docker::run restart policy set

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -72,6 +72,10 @@ module Puppet::Parser::Functions
       flags.concat(new_flags)
     end
 
+    opts['extra_params'].each do |param|
+      flags << param
+    end
+
     flags.flatten.join(" ")
   end
 end

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -89,7 +89,6 @@ define docker::run(
     $valid_detach = $detach
   }
 
-  $extra_parameters_array = any2array($extra_parameters)
   $depends_array = any2array($depends)
 
   $docker_run_flags = docker_run_flags({
@@ -101,6 +100,7 @@ define docker::run(
     env             => any2array($env),
     env_file        => any2array($env_file),
     expose          => any2array($expose),
+    extra_params    => any2array($extra_parameters),
     hostentries     => any2array($hostentries),
     hostname        => $hostname,
     links           => any2array($links),

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -336,6 +336,15 @@ require 'spec_helper'
       end
     end
 
+    context 'with restart policy' do
+      let(:params) { {'restart' => 'no', 'command' => 'command', 'image' => 'base', 'extra_parameters' => '-c 4'} }
+      it { should contain_exec('run sample with docker') }
+      it { should contain_exec('run sample with docker').with_unless(/\/var\/run\/docker-sample.cid/) }
+      it { should contain_exec('run sample with docker').with_command(/--cidfile=\/var\/run\/docker-sample.cid/) }
+      it { should contain_exec('run sample with docker').with_command(/-c 4/) }
+      it { should contain_exec('run sample with docker').with_command(/base command/) }
+    end
+
   end
   end
 

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -71,9 +71,6 @@ start() {
     $docker run \
     <%= @docker_run_flags %> \
     --name <%= @sanitised_title %> \
-    <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
-        <%= param %> <% end %> \
-    <% end -%> \
     <%= @image %> \
     <% if @command %> <%= @command %><% end %>
 

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -20,9 +20,6 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> rm <%= @sanitised_title %>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <%= @docker_run_flags %> \
         --name <%= @sanitised_title %> \
-        <% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
-            <%= param %> <% end %> \
-        <% end -%> \
         <%= @image %> \
         <% if @command %> <%= @command %><% end %>
 ExecStop=-/usr/bin/<%= @docker_command %> stop <%= @sanitised_title %>


### PR DESCRIPTION
The `extra_parameters` parameter has no effect with a restart policy is set. e.g.

```puppet
  docker::run { 'sample':
    image            => $image,
    extra_parameters => ['--log-driver=syslog'],
    restart          => 'no',
  }
```

In this example, the `--log-driver` option will never be passed to `docker run ...`.

This PR simplifies the existing `extra_parameters` handling by moving it into `docker_run_flags`. This way the `docker-run` init templates can be simplified and also fixes the above issue.