### PR TITLE
Execute command before stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ docker::run { 'helloworld':
   restart_service => true,
   privileged      => false,
   pull_on_start   => false,
+  before_stop     => 'echo "So Long, and Thanks for All the Fish"',
   depends         => [ 'container_a', 'postgres' ],
 }
 ```
@@ -222,6 +223,8 @@ docker::run { 'helloworld':
 Ports, expose, env, env_file, dns and volumes can be set with either a single string or as above with an array of values.
 
 Specifying `pull_on_start` will pull the image before each time it is started.
+
+Specifying `before_stop` will execute a command before stopping the container.
 
 The `depends` option allows expressing containers that must be started before. This affects the generation of the init.d/systemd script.
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -54,6 +54,7 @@ define docker::run(
   $socket_connect = [],
   $hostentries = [],
   $restart = undef,
+  $before_stop = false,
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -272,6 +272,16 @@ require 'spec_helper'
       it { should_not contain_file(initscript).with_content(/docker pull base/) }
     end
 
+    context 'when `before_stop` is set' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'before_stop' => "echo before_stop" } }
+      it { should contain_file(initscript).with_content(/before_stop/) }
+    end
+
+    context 'when `before_stop` is not set' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'before_stop' => false } }
+      it { should_not contain_file(initscript).with_content(/before_stop/) }
+    end
+
     context 'with an title that will not format into a path' do
       let(:title) { 'this/that' }
       let(:params) { {'image' => 'base'} }

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -88,6 +88,9 @@ start() {
 
 stop() {
     echo -n "Stopping $prog: "
+    <% if @before_stop -%>
+        <%= @before_stop %>
+    <% end -%>
     $docker stop <%= @sanitised_title %>
     $docker rm <%= @sanitised_title %>
     return $?

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -25,6 +25,8 @@ ExecStart=/usr/bin/<%= @docker_command %> run \
         <% end -%> \
         <%= @image %> \
         <% if @command %> <%= @command %><% end %>
+<%- if @before_stop %>ExecStop=-<%= @before_stop %>
+<% end -%>
 ExecStop=-/usr/bin/<%= @docker_command %> stop <%= @sanitised_title %>
 
 [Install]


### PR DESCRIPTION
Add (optional) command to execute before shutting down a container:

docker::run { "myinstance":
	...
	before_stop => "/path/to/my_clean_shutdown_commmand",
}