### PR TITLE
Improve docker::run service configuration

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -18,6 +18,19 @@
 # This will allow the docker container to be restarted if it dies, without
 # puppet help.
 #
+# [*service_prefix*]
+#   (optional) The name to prefix the startup script with and the Puppet
+#   service resource title with.  Default: 'docker-'
+#
+# [*restart_service*]
+#   (optional) Whether or not to restart the service if the the generated init
+#   script changes.  Default: true
+#
+# [*manage_service*]
+#  (optional) Whether or not to create a puppet Service resource for the init
+#  script.  Disabling this may be useful if integrating with existing modules.
+#  Default: true
+#
 # [*extra_parameters*]
 # An array of additional command line arguments to pass to the `docker run`
 # command. Useful for adding additional new or experimental options that the
@@ -43,7 +56,9 @@ define docker::run(
   $dns = [],
   $dns_search = [],
   $lxc_conf = [],
+  $service_prefix = 'docker-',
   $restart_service = true,
+  $manage_service = true,
   $disable_network = false,
   $privileged = false,
   $detach = undef,
@@ -138,22 +153,22 @@ define docker::run(
 
     case $::osfamily {
       'Debian': {
-        $initscript = "/etc/init.d/docker-${sanitised_title}"
+        $initscript = "/etc/init.d/${service_prefix}${sanitised_title}"
         $init_template = 'docker/etc/init.d/docker-run.erb'
-        $deprecated_initscript = "/etc/init/docker-${sanitised_title}.conf"
+        $deprecated_initscript = "/etc/init/${service_prefix}${sanitised_title}.conf"
         $hasstatus  = true
         $uses_systemd = false
         $mode = '0755'
       }
       'RedHat': {
         if ($::operatingsystem == 'Amazon') or (versioncmp($::operatingsystemrelease, '7.0') < 0) {
-          $initscript     = "/etc/init.d/docker-${sanitised_title}"
+          $initscript     = "/etc/init.d/${service_prefix}${sanitised_title}"
           $init_template  = 'docker/etc/init.d/docker-run.erb'
           $hasstatus      = undef
           $mode           = '0755'
           $uses_systemd   = false
         } else {
-          $initscript     = "/etc/systemd/system/docker-${sanitised_title}.service"
+          $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template  = 'docker/etc/systemd/system/docker-run.erb'
           $hasstatus      = true
           $mode           = '0644'
@@ -161,7 +176,7 @@ define docker::run(
         }
       }
       'Archlinux': {
-        $initscript     = "/etc/systemd/system/docker-${sanitised_title}.service"
+        $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
         $init_template  = 'docker/etc/systemd/system/docker-run.erb'
         $hasstatus      = true
         $mode           = '0644'
@@ -178,40 +193,42 @@ define docker::run(
       mode    => $mode,
     }
 
-    # Transition help from moving from CID based container detection to
-    # Name-based container detection. See #222 for context.
-    # This code should be considered temporary until most people have
-    # transitioned. - 2015-04-15
-    if $initscript == "/etc/init.d/docker-${sanitised_title}" {
-      # This exec sequence will ensure the old-style CID container is stopped
-      # before we replace the init script with the new-style.
-      exec { "/bin/sh /etc/init.d/docker-${sanitised_title} stop":
-        onlyif  => "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid && /usr/bin/test -f /etc/init.d/docker-${sanitised_title}",
-        require => [],
-      } ->
-      file { "/var/run/docker-${sanitised_title}.cid":
-        ensure => absent,
-      } ->
-      File[$initscript]
-    }
+    if $manage_service {
+      # Transition help from moving from CID based container detection to
+      # Name-based container detection. See #222 for context.
+      # This code should be considered temporary until most people have
+      # transitioned. - 2015-04-15
+      if $initscript == "/etc/init.d/${service_prefix}${sanitised_title}" {
+        # This exec sequence will ensure the old-style CID container is stopped
+        # before we replace the init script with the new-style.
+        exec { "/bin/sh /etc/init.d/${service_prefix}${sanitised_title} stop":
+          onlyif  => "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid && /usr/bin/test -f /etc/init.d/${service_prefix}${sanitised_title}",
+          require => [],
+        } ->
+        file { "/var/run/docker-${sanitised_title}.cid":
+          ensure => absent,
+        } ->
+        File[$initscript]
+      }
 
-    service { "docker-${sanitised_title}":
-      ensure    => $running,
-      enable    => true,
-      hasstatus => $hasstatus,
-      require   => File[$initscript],
+      service { "${service_prefix}${sanitised_title}":
+        ensure    => $running,
+        enable    => true,
+        hasstatus => $hasstatus,
+        require   => File[$initscript],
+      }
     }
 
     if $uses_systemd {
       File[$initscript] ~> Exec['docker-systemd-reload']
-      Exec['docker-systemd-reload'] -> Service["docker-${sanitised_title}"]
+      Exec['docker-systemd-reload'] -> Service<| title == "${service_prefix}${sanitised_title}" |>
     }
 
     if $restart_service {
-      File[$initscript] ~> Service["docker-${sanitised_title}"]
+      File[$initscript] ~> Service<| title == "${service_prefix}${sanitised_title}" |>
     }
     else {
-      File[$initscript] -> Service["docker-${sanitised_title}"]
+      File[$initscript] -> Service<| title == "${service_prefix}${sanitised_title}" |>
     }
   }
 }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -288,6 +288,38 @@ require 'spec_helper'
       it { should contain_file(new_initscript) }
     end
 
+    context 'with manage_service turned off' do
+      let(:title) { 'this/that' }
+      let(:params) { {'image' => 'base', 'manage_service' => false} }
+
+      if osfamily == 'Debian'
+        new_initscript = '/etc/init.d/docker-this-that'
+      elsif osfamily == 'Archlinux'
+        new_initscript = '/etc/systemd/system/docker-this-that.service'
+      else
+        new_initscript = '/etc/init.d/docker-this-that'
+      end
+
+      it { should_not contain_service('docker-this-that') }
+      it { should contain_file(new_initscript) }
+    end
+
+    context 'with service_prefix set to empty string' do
+      let(:title) { 'this/that' }
+      let(:params) { {'image' => 'base', 'service_prefix' => ''} }
+
+      if osfamily == 'Debian'
+        new_initscript = '/etc/init.d/this-that'
+      elsif osfamily == 'Archlinux'
+        new_initscript = '/etc/systemd/system/this-that.service'
+      else
+        new_initscript = '/etc/init.d/this-that'
+      end
+
+      it { should contain_service('this-that') }
+      it { should contain_file(new_initscript) }
+    end
+
     context 'with an invalid title' do
       let(:title) { 'with spaces' }
       it do

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -11,9 +11,9 @@
 # description: Docker container for <%= @title %>
 
 ### BEGIN INIT INFO
-# Provides:       docker-<%= @sanitised_title %>
-# Required-Start: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " docker-#{d}" %><% end %><% end %>
-# Required-Stop: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " docker-#{d}" %><% end %><% end %>
+# Provides:       <%= @service_prefix %><%= @sanitised_title %>
+# Required-Start: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
+# Required-Stop: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
 # Should-Start:
 # Should-Stop:
 # Default-Start: 2 3 4 5
@@ -47,7 +47,7 @@ fi
 
 export HOME=/root/
 docker="/usr/bin/<%= @docker_command %>"
-prog="docker-<%= @sanitised_title %>"
+prog="<%= @service_prefix %><%= @sanitised_title %>"
 if [ -d /var/lock/subsys ]; then
     lockfile="/var/lock/subsys/$prog"
 else

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -3,8 +3,8 @@
 
 [Unit]
 Description=Daemon for <%= @title %>
-After=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " docker-#{d}.service" %><% end %><% end %>
-Requires=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " docker-#{d}.service" %><% end %><% end %>
+After=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
+Requires=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
 
 [Service]
 <%- if @username -%>User=<%= @username %><%- end -%>


### PR DESCRIPTION
Added two new parameters:

The `service_prefix` parameter allows overriding the prefix that is
applied to the service resource and the init script.  This makes it
easier to integrate with existing modules that have specific service
names in place.

The second parameter 'manage_service' allows turning off the creation of
the service resource.  Again, this makes it easier to integate with
existing modules that already manage the resource.  The restart_service
parameter will continue to notify the service if it is found under a
matching name.