### PR TITLE
Add wrapper for docker run commands

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -48,6 +48,14 @@ module Puppet::Parser::Functions
       flags << '-t'
     end
 
+    if opts['rm']
+      flags << '--rm'
+    end
+
+    if opts['interactive']
+      flags << '--interactive'
+    end
+
     multi_flags = lambda { |values, format|
       filtered = [values].flatten.compact
       filtered.map { |val| sprintf(format, val) }

--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -1,0 +1,133 @@
+# == Define: docker::command
+#
+# A define which creates a shell wrapper run a command inside docker container.
+#
+# == Parameters
+#
+# [*wrapper_path*]
+# This is the absolute path to the command wrapper to create.  This defaults to
+# the title of the resource.
+#
+# [*ensure*]
+# Ensure the state of the wrapper script.  Defaults to 'file'.  May be set to
+# 'absent' to remove obsolete commands.
+#
+# [*command*]
+# This is the command to execute inside of the container.  Required.
+#
+# [*extra_parameters*]
+# An array of additional command line arguments to pass to the `docker run`
+# command. Useful for adding additional new or experimental options that the
+# module does not yet support.
+#
+# [*owner*]
+# Owner of the wrapper script.  Defaults to 'root'.
+#
+# [*group*]
+# Group of the wrapper script.  Defaults to 'root'.
+#
+# [*mode*]
+# Mode of the wrapper script.  Defaults to '0755'.
+#
+define docker::command(
+  $image,
+  $command,
+  $wrapper_path = $title,
+  $ensure = 'file',
+  $memory_limit = '0b',
+  $cpuset = [],
+  $ports = [],
+  $labels = [],
+  $expose = [],
+  $volumes = [],
+  $links = [],
+  $volumes_from = [],
+  $net = 'bridge',
+  $username = false,
+  $hostname = false,
+  $env = [],
+  $env_file = [],
+  $dns = [],
+  $dns_search = [],
+  $lxc_conf = [],
+  $disable_network = false,
+  $privileged = false,
+  $detach = false,
+  $extra_parameters = undef,
+  $pull_on_start = false,
+  $tty = false,
+  $interactive = true,
+  $rm = true,
+  $socket_connect = [],
+  $hostentries = [],
+  $owner = 'root',
+  $group = 'root',
+  $mode = '0755',
+) {
+  include docker::params
+  if ($socket_connect != []) {
+    $sockopts = join(any2array($socket_connect), ',')
+    $docker_command = "${docker::params::docker_command} -H ${sockopts}"
+  }else {
+    $docker_command = $docker::params::docker_command
+  }
+
+  validate_re($image, '^[\S]*$')
+  validate_re($wrapper_path, '^\/[\S]+$')
+  validate_re($command, '^\/.+$')
+  validate_re($ensure, '^(file|absent)$')
+  validate_re($memory_limit, '^[\d]*(b|k|m|g)$')
+  validate_string($docker_command)
+  if $username {
+    validate_string($username)
+  }
+  if $hostname {
+    validate_string($hostname)
+  }
+  validate_bool($disable_network)
+  validate_bool($privileged)
+  validate_bool($tty)
+  validate_bool($interactive)
+  validate_bool($rm)
+  validate_bool($detach)
+
+  $extra_parameters_array = any2array($extra_parameters)
+
+  $docker_run_flags = docker_run_flags({
+    cpuset          => any2array($cpuset),
+    detach          => $detach,
+    disable_network => $disable_network,
+    dns             => any2array($dns),
+    dns_search      => any2array($dns_search),
+    env             => any2array($env),
+    env_file        => any2array($env_file),
+    expose          => any2array($expose),
+    extra_params    => any2array($extra_parameters),
+    hostentries     => any2array($hostentries),
+    hostname        => $hostname,
+    links           => any2array($links),
+    lxc_conf        => any2array($lxc_conf),
+    memory_limit    => $memory_limit,
+    net             => $net,
+    ports           => any2array($ports),
+    labels          => any2array($labels),
+    privileged      => $privileged,
+    socket_connect  => any2array($socket_connect),
+    tty             => $tty,
+    interactive     => $interactive,
+    rm              => $rm,
+    username        => $username,
+    volumes         => any2array($volumes),
+    volumes_from    => any2array($volumes_from),
+  })
+
+  $sanitised_title = regsubst(regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G'), '^-', '')
+
+  file { $title:
+    ensure  => $ensure,
+    content => template('docker/docker-command.erb'),
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+  }
+}

--- a/spec/defines/command_spec.rb
+++ b/spec/defines/command_spec.rb
@@ -1,0 +1,315 @@
+require 'spec_helper'
+
+params = {
+  :command => '/usr/bin/sample',
+  :image   => 'base',
+}
+
+['Debian', 'RedHat', 'Archlinux'].each do |osfamily|
+
+  describe 'docker::command', :type => :define do
+    let(:title) { '/usr/bin/wrapper' }
+    let(:params) { params }
+
+    context "on #{osfamily}" do
+      if osfamily == 'Debian'
+        let(:facts) { {
+          :osfamily               => 'Debian',
+          :lsbdistid              => 'Ubuntu',
+          :operatingsystem        => 'Ubuntu',
+          :lsbdistcodename        => 'trusty',
+          :operatingsystemrelease => '14.04',
+          :kernelrelease          => '3.8.0-29-generic'
+        } }
+        initscript = '/etc/init.d/docker-sample'
+        command = 'docker'
+        systemd = false
+      elsif osfamily == 'Archlinux'
+        let(:facts) { {:osfamily => osfamily} }
+        initscript = '/etc/systemd/system/docker-sample.service'
+        command = 'docker'
+        systemd = true
+      elsif osfamily == 'RedHat'
+        let(:facts) { {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'RedHat',
+          :operatingsystemrelease => '6.6',
+          :operatingsystemmajrelease => '6',
+          :kernelversion => '2.6.32',
+        } }
+        initscript = '/etc/init.d/docker-sample'
+        command = 'docker'
+        systemd = false
+      else
+        let(:facts) { {
+          :osfamily => 'RedHat',
+          :operatingsystem => 'Amazon',
+          :operatingsystemrelease => '2015.09',
+          :operatingsystemmajrelease => '2015',
+          :kernelversion => '2.6.32',
+        } }
+        initscript = '/etc/init.d/docker-sample'
+        command = 'docker'
+        systemd = false
+      end
+
+      context 'passing the required params' do
+        it { should compile.with_all_deps }
+        it { should contain_file('/usr/bin/wrapper') }
+        it { should contain_file('/usr/bin/wrapper').with_content(/\$docker run/) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/\/usr\/bin\/sample/) }
+        it { should contain_file('/usr/bin/wrapper').with_mode('0755') }
+
+        ['p', 'dns', 'H', 'dns-search', 'u', 'v', 'e', 'n', 't', 'volumes-from', 'name'].each do |search|
+          it { should_not contain_file('/usr/bin/wrapper').with_content(/-${search}/) }
+        end
+      end
+
+      context 'when lxc_conf disables swap' do
+        let(:params) { params.merge({'lxc_conf' => 'lxc.cgroup.memory.memsw.limit_in_bytes=536870912'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-lxc-conf=\"lxc.cgroup.memory.memsw.limit_in_bytes=536870912\"/) }
+      end
+
+      context 'when passing a memory limit in bytes' do
+        let(:params) { params.merge({'memory_limit' => '1000b'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-m 1000b/) }
+      end
+
+      context 'when passing a cpuset' do
+        let(:params) { params.merge({'cpuset' => '3'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--cpuset=3/) }
+      end
+
+      context 'when passing a multiple cpu cpuset' do
+        let(:params) { params.merge({'cpuset' => ['0', '3']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--cpuset=0,3/) }
+      end
+
+      context 'when not passing a cpuset' do
+        it { should contain_file('/usr/bin/wrapper').without_content(/--cpuset=/) }
+      end
+
+      context 'when passing a links option' do
+        let(:params) { params.merge({'links' => ['example:one', 'example:two']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/ --link example:one --link example:two /) }
+      end
+
+      context 'when passing a hostname' do
+        let(:params) { params.merge({'hostname' => 'example.com'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-h 'example.com'/) }
+      end
+
+      context 'when not passing a hostname' do
+        it { should contain_file('/usr/bin/wrapper').without_content(/-h ''/) }
+      end
+
+      context 'when passing a username' do
+        let(:params) { params.merge({'username' => 'bob'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-u 'bob'/) }
+      end
+
+      context 'when not passing a username' do
+        it { should contain_file('/usr/bin/wrapper').without_content(/-u ''/) }
+      end
+
+      context 'when passing a port number' do
+        let(:params) { params.merge({'ports' => '4444'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-p 4444/) }
+      end
+
+      context 'when passing a port to expose' do
+        let(:params) { params.merge({'expose' => '4666'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--expose=4666/) }
+      end
+
+      context 'when passing a hostentry' do
+        let(:params) { params.merge({'hostentries' => 'dummyhost:127.0.0.2'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--add-host dummyhost:127.0.0.2/) }
+      end
+
+      context 'when connecting to shared data volumes' do
+        let(:params) { params.merge({'volumes_from' => '6446ea52fbc9'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--volumes-from 6446ea52fbc9/) }
+      end
+
+      context 'when connecting to several shared data volumes' do
+        let(:params) { params.merge({'volumes_from' => ['sample-linked-container-1', 'sample-linked-container-2']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--volumes-from sample-linked-container-1/) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--volumes-from sample-linked-container-2/) }
+      end
+
+      context 'when passing several port numbers' do
+        let(:params) { params.merge({'ports' => ['4444', '4555']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-p 4444/).with_content(/-p 4555/) }
+      end
+
+      context 'when passing several ports to expose' do
+        let(:params) { params.merge({'expose' => ['4666', '4777']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--expose=4666/).with_content(/--expose=4777/) }
+      end
+
+      context 'when passing several environment variables' do
+        let(:params) { params.merge({'env' => ['FOO=BAR', 'FOO2=BAR2']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-e FOO=BAR/).with_content(/-e FOO2=BAR2/) }
+      end
+
+      context 'when passing an environment variable' do
+        let(:params) { params.merge({'env' => 'FOO=BAR'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-e FOO=BAR/) }
+      end
+
+      context 'when passing several environment files' do
+        let(:params) { params.merge({'env_file' => ['/etc/foo.env', '/etc/bar.env']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--env-file \/etc\/foo.env/).with_content(/--env-file \/etc\/bar.env/) }
+      end
+
+      context 'when passing an environment file' do
+        let(:params) { params.merge({'env_file' => '/etc/foo.env'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--env-file \/etc\/foo.env/) }
+      end
+
+      context 'when passing several dns addresses' do
+        let(:params) { params.merge({'dns' => ['8.8.8.8', '8.8.4.4']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--dns 8.8.8.8/).with_content(/--dns 8.8.4.4/) }
+      end
+
+      context 'when passing a dns address' do
+        let(:params) { params.merge({'dns' => '8.8.8.8'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--dns 8.8.8.8/) }
+      end
+
+      context 'when passing several sockets to connect to' do
+        let(:params) { params.merge({'socket_connect' => ['tcp://127.0.0.1:4567', 'tcp://127.0.0.2:4567']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-H tcp:\/\/127.0.0.1:4567/) }
+      end
+
+      context 'when passing a socket to connect to' do
+        let(:params) { params.merge({'socket_connect' => 'tcp://127.0.0.1:4567'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-H tcp:\/\/127.0.0.1:4567/) }
+      end
+
+      context 'when passing several dns search domains' do
+        let(:params) { params.merge({'dns_search' => ['my.domain.local', 'other-domain.de']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--dns-search my.domain.local/).with_content(/--dns-search other-domain.de/) }
+      end
+
+      context 'when passing a dns search domain' do
+        let(:params) { params.merge({'dns_search' => 'my.domain.local'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--dns-search my.domain.local/) }
+      end
+
+      context 'when disabling network' do
+        let(:params) { params.merge({'disable_network' => true}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-n false/) }
+      end
+
+      context 'when running privileged' do
+        let(:params) { params.merge({'privileged' => true}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--privileged/) }
+      end
+
+      context 'should run without detached value' do
+        it { should contain_file('/usr/bin/wrapper').without_content(/--detach=true/) }
+      end
+
+      context 'should be able to override detached' do
+        let(:params) { params.merge({'detach' => true}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--detach=true/) }
+      end
+
+      context 'when running with a tty' do
+        let(:params) { params.merge({'tty' => true}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-t/) }
+      end
+
+      context 'when passing several extra parameters' do
+        let(:params) { params.merge({'extra_parameters' => ['--test', '-w /tmp']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--test/).with_content(/-w \/tmp/) }
+      end
+
+      context 'when passing an extra parameter' do
+        let(:params) { params.merge({'extra_parameters' => '-c 4'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-c 4/) }
+      end
+
+      context 'when passing a data volume' do
+        let(:params) { params.merge({'volumes' => '/var/log'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-v \/var\/log/) }
+      end
+
+      context 'when passing several data volume' do
+        let(:params) { params.merge({'volumes' => ['/var/lib/couchdb', '/var/log']}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-v \/var\/lib\/couchdb/) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/-v \/var\/log/) }
+      end
+
+      context 'when using network mode' do
+        let(:params) { params.merge({'net' => 'host'}) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/--net host/) }
+      end
+
+      context 'when `pull_on_start` is true' do
+        let(:params) { params.merge({'pull_on_start' => true }) }
+        it { should contain_file('/usr/bin/wrapper').with_content(/docker pull base/) }
+      end
+
+      context 'when `pull_on_start` is false' do
+        let(:params) { params.merge({'pull_on_start' => false }) }
+        it { should_not contain_file('/usr/bin/wrapper').with_content(/docker pull base/) }
+      end
+
+      context 'when `owner` is overridden' do
+        let(:params) { params.merge({'owner' => 'nobody' }) }
+        it { should contain_file('/usr/bin/wrapper').with_owner('nobody') }
+      end
+
+      context 'when `group` is overridden' do
+        let(:params) { params.merge({'group' => 'nogroup' }) }
+        it { should contain_file('/usr/bin/wrapper').with_group('nogroup') }
+      end
+
+      context 'when `mode` is overridden' do
+        let(:params) { params.merge({'mode' => '0750' }) }
+        it { should contain_file('/usr/bin/wrapper').with_mode('0750') }
+      end
+
+      context 'with an title that will not format into a path' do
+        let(:title) { 'this/that' }
+
+        it do
+          expect {
+            should contain_file('/usr/bin/wrapper')
+          }.to raise_error(Puppet::Error)
+        end
+      end
+
+      context 'with an invalid image name' do
+        let(:params) { params.merge({'image' => 'with spaces' }) }
+        it do
+          expect {
+            should contain_file('/usr/bin/wrapper')
+          }.to raise_error(Puppet::Error)
+        end
+      end
+
+      context 'with an invalid memory value' do
+        let(:params) { params.merge({'memory' => 'not a number'}) }
+        it do
+          expect {
+            should contain_file('/usr/bin/wrapper')
+          }.to raise_error(Puppet::Error)
+        end
+      end
+
+      context 'with a missing memory unit' do
+        let(:params) { params.merge({'memory' => '10240'}) }
+        it do
+          expect {
+            should contain_file('/usr/bin/wrapper')
+          }.to raise_error(Puppet::Error)
+        end
+      end
+
+    end
+  end
+end

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -343,7 +343,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--expose=4666/).with_content(/--expose=4777/) }
     end
 
-    context 'when passing serveral environment variables' do
+    context 'when passing several environment variables' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'env' => ['FOO=BAR', 'FOO2=BAR2']} }
       it { should contain_file(initscript).with_content(/-e FOO=BAR/).with_content(/-e FOO2=BAR2/) }
     end
@@ -353,7 +353,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/-e FOO=BAR/) }
     end
 
-    context 'when passing serveral environment files' do
+    context 'when passing several environment files' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'env_file' => ['/etc/foo.env', '/etc/bar.env']} }
       it { should contain_file(initscript).with_content(/--env-file \/etc\/foo.env/).with_content(/--env-file \/etc\/bar.env/) }
     end
@@ -363,7 +363,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--env-file \/etc\/foo.env/) }
     end
 
-    context 'when passing serveral dns addresses' do
+    context 'when passing several dns addresses' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'dns' => ['8.8.8.8', '8.8.4.4']} }
       it { should contain_file(initscript).with_content(/--dns 8.8.8.8/).with_content(/--dns 8.8.4.4/) }
     end
@@ -373,7 +373,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--dns 8.8.8.8/) }
     end
 
-    context 'when passing serveral sockets to connect to' do
+    context 'when passing several sockets to connect to' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'socket_connect' => ['tcp://127.0.0.1:4567', 'tcp://127.0.0.2:4567']} }
       it { should contain_file(initscript).with_content(/-H tcp:\/\/127.0.0.1:4567/) }
     end
@@ -383,7 +383,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/-H tcp:\/\/127.0.0.1:4567/) }
     end
 
-    context 'when passing serveral dns search domains' do
+    context 'when passing several dns search domains' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'dns_search' => ['my.domain.local', 'other-domain.de']} }
       it { should contain_file(initscript).with_content(/--dns-search my.domain.local/).with_content(/--dns-search other-domain.de/) }
     end
@@ -422,7 +422,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/-t/) }
     end
 
-    context 'when passing serveral extra parameters' do
+    context 'when passing several extra parameters' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'extra_parameters' => ['--rm', '-w /tmp']} }
       it { should contain_file(initscript).with_content(/--rm/).with_content(/-w \/tmp/) }
     end
@@ -437,7 +437,7 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/-v \/var\/log/) }
     end
 
-    context 'when passing serveral data volume' do
+    context 'when passing several data volume' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'volumes' => ['/var/lib/couchdb', '/var/log']} }
       it { should contain_file(initscript).with_content(/-v \/var\/lib\/couchdb/) }
       it { should contain_file(initscript).with_content(/-v \/var\/log/) }

--- a/templates/docker-command.erb
+++ b/templates/docker-command.erb
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# This file is managed by Puppet and local changes
+# may be overwritten
+#
+#    Wrapper command for <%= @title %>
+#
+
+export HOME=/root/
+docker="/usr/bin/<%= @docker_command %>"
+
+[ -x $docker ] || exit 5
+
+<% if @pull_on_start -%>
+    $docker pull <%= @image %>
+<% end -%>
+exec $docker run \
+    <%= @docker_run_flags %> \
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %>  \
+    <%= param %> <% end %> \
+<% end -%> \
+    <%= @image %> \
+    <%= @command %> "$@"


### PR DESCRIPTION
This adds a new defined type that follows the pattern that the
docker::run defined type has already set out.  Instead of generating an
init script, it generates a shell wrapper to run a command via docker
run.  By default, the container it is run in will be unnamed and deleted
after the command exists.  This can is useful when converting existing
tools from packages to docker containers since it can allow them to
continue running the same commands via the generated wrappers.
