### PR TITLE
Fix memory_limit format on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ docker::run { 'helloworld':
   use_name        => true,
   volumes         => ['/var/lib/couchdb', '/var/log'],
   volumes_from    => '6446ea52fbc9',
-  memory_limit    => 10m, # (format: <number><unit>, where unit = b, k, m or g)
+  memory_limit    => '10m', # (format: '<number><unit>', where unit = b, k, m or g)
   cpuset          => ['0', '3'],
   username        => 'example',
   hostname        => 'example.com',


### PR DESCRIPTION
`memory_limit` values must be specified within single quotes