### PR TITLE
fix Debian support 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,18 +38,9 @@ class docker::params {
   $docker_group_default         = 'docker'
   case $::osfamily {
     'Debian' : {
-      case $::operatingsystem {
-        'Ubuntu' : {
-          $package_name   = $package_name_default
-          $service_name   = $service_name_default
-          $docker_command = $docker_command_default
-        }
-        default: {
-          $package_name   = 'docker.io'
-          $service_name   = 'docker.io'
-          $docker_command = 'docker.io'
-        }
-      }
+      $package_name   = $package_name_default
+      $service_name   = $service_name_default
+      $docker_command = $docker_command_default
       $docker_group = $docker_group_default
       $package_source_location     = 'https://get.docker.com/ubuntu'
       $use_upstream_package_source = true

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -315,7 +315,7 @@ describe 'docker', :type => :class do
     context 'with no upstream package source' do
       let(:params) { {'use_upstream_package_source' => false } }
       it { should_not contain_apt__source('docker') }
-      it { should contain_package('docker').with_name('docker.io') }
+      it { should contain_package('docker').with_name('lxc-docker') }
     end
   end
 

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -10,7 +10,7 @@ require 'spec_helper'
 
     if osfamily == 'Debian'
       initscript = '/etc/init.d/docker-sample'
-      command = 'docker.io'
+      command = 'docker'
       systemd = false
     elsif osfamily == 'Archlinux'
       initscript = '/etc/systemd/system/docker-sample.service'


### PR DESCRIPTION
 * command is called `docker`
 * package is called `lxc-docker`
 * allow changing parameters on any Debian based distro

Current implementation doesn't allow to modify `$package_name` simply by passing different `$package_name_default` on Debian. 
