### PR TITLE
Fact to report the number of running containers

### DIFF
--- a/lib/facter/docker_running_container.rb
+++ b/lib/facter/docker_running_container.rb
@@ -1,0 +1,18 @@
+
+# Fact: docker_running_container
+#
+# Purpose: 
+#   Get the number of running containers
+#
+# Resolution:
+#   Use docker ps to obtain the number of running containers.
+#
+# Caveats:
+#   The user used by Puppet to execute this fact must have the rights to call the 'docker' command.
+#
+Facter.add(:docker_running_container) do
+  setcode do
+    docker_ps_raw = Facter::Util::Resolution.exec('docker ps | wc -l')
+    docker_running_container = docker_ps_raw.to_i - 1
+  end
+end


### PR DESCRIPTION
Simple Fact using 'docker ps' to report with Facter the number of running containers.
Since there are no Fact in this module today, hints or an update to the PR guidelines around Facter testing could be nice.