### PR TITLE
Remove apt::source ~> apt_update dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,5 +80,5 @@ run the integration tests against Centos 6.5 with:
 
 Or with Ubuntu 14.04 with:
 
-    BEAKER_set=ubuntu-server-1404-x64 bundle exec rake beaker
+    BEAKER_set=ubuntu-1404-x64 bundle exec rake beaker
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ class { 'docker':
 }
 ```
 
+Docker Inc recently [launched new official
+repositories](http://blog.docker.com/2015/07/new-apt-and-yum-repos/#comment-247448)
+which are now the default for the module from version 5. If you want to
+stick with the old respoitories you can do so with the following:
+
+```puppet
+class { 'docker':
+  package_name => 'lxc-docker',
+  package_source_location => 'https://get.docker.com/ubuntu',
+  package_key_source => 'https://get.docker.com/gpg',
+  package_key => '36A1D7869245C8950F966E92D8576A8BA88D21E',
+  package_release => 'docker',
+}
+```
+
+The module also now uses the upstream repositories by default for RHEL
+based distros, including Fedora. If you want to stick with the distro packages
+you should use the following:
+
+```puppet
+class { 'docker':
+  use_upstream_package_source => false,
+  package_name => 'docker',
+}
+```
+
 By default the docker daemon will bind to a unix socket at
 /var/run/docker.sock. This can be changed, as well as binding to a tcp
 socket if required.

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ end
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.send('disable_case_without_default')
 PuppetLint.configuration.fail_on_warnings = true
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.

--- a/files/service-overrides-rhel.conf
+++ b/files/service-overrides-rhel.conf
@@ -1,0 +1,10 @@
+[Service]
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+ExecStart=
+ExecStart=/usr/bin/docker -d -H fd:// $OPTIONS \
+      $DOCKER_STORAGE_OPTIONS \
+      $DOCKER_NETWORK_OPTIONS \
+      $BLOCK_REGISTRY \
+      $INSECURE_REGISTRY

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,6 +156,10 @@ class docker(
   $selinux_enabled             = $docker::params::selinux_enabled,
   $use_upstream_package_source = $docker::params::use_upstream_package_source,
   $package_source_location     = $docker::params::package_source_location,
+  $package_release             = $docker::params::package_release,
+  $package_repos               = $docker::params::package_repos,
+  $package_key                 = $docker::params::package_key,
+  $package_key_source          = $docker::params::package_key_source,
   $service_state               = $docker::params::service_state,
   $service_enable              = $docker::params::service_enable,
   $root_dir                    = $docker::params::root_dir,
@@ -219,9 +223,11 @@ class docker(
     fail('You need to provide both $dm_datadev and $dm_metadatadev parameters for direct lvm.')
   }
 
+  class { 'docker::repos': } ->
   class { 'docker::install': } ->
   class { 'docker::config': } ~>
   class { 'docker::service': }
+  contain 'docker::repos'
   contain 'docker::install'
   contain 'docker::config'
   contain 'docker::service'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,8 +31,7 @@ class docker::params {
   $dm_metadatadev               = undef
   $manage_package               = true
   $manage_kernel                = true
-  $manage_epel                  = true
-  $package_name_default         = 'lxc-docker'
+  $package_name_default         = 'docker-engine'
   $service_name_default         = 'docker'
   $docker_command_default       = 'docker'
   $docker_group_default         = 'docker'
@@ -40,36 +39,57 @@ class docker::params {
     'Debian' : {
       case $::operatingsystem {
         'Ubuntu' : {
-          $package_name   = $package_name_default
-          $service_name   = $service_name_default
-          $docker_command = $docker_command_default
+          $package_release = "ubuntu-${::lsbdistcodename}"
+          if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+            include docker::systemd_reload
+          }
         }
         default: {
-          $package_name   = 'docker.io'
-          $service_name   = 'docker.io'
-          $docker_command = 'docker.io'
+          $package_release = "debian-${::lsbdistcodename}"
+          if (versioncmp($::distrelease, '8') >= 0) {
+            include docker::systemd_reload
+          }
         }
       }
+
+      $manage_epel = false
+      $package_name = $package_name_default
+      $service_name = $service_name_default
+      $docker_command = $docker_command_default
       $docker_group = $docker_group_default
-      $package_source_location     = 'https://get.docker.com/ubuntu'
+      $package_source_location = 'https://apt.dockerproject.org/repo'
+      $package_key_source = 'https://apt.dockerproject.org/gpg'
+      $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
+      $package_repos = 'main'
       $use_upstream_package_source = true
       $detach_service_in_init = true
       $repo_opt = undef
       $nowarn_kernel = false
     }
     'RedHat' : {
-      if $::operatingsystem == 'Fedora' {
-        $package_name   = 'docker-io'
+      if (versioncmp($::operatingsystemrelease, '7.0') < 0) and $::operatingsystem != 'Amazon' {
+        $package_name = 'docker-io'
         $use_upstream_package_source = false
-      } elsif (versioncmp($::operatingsystemrelease, '7.0') < 0) and $::operatingsystem != 'Amazon' {
-        $package_name   = 'docker-io'
-        $use_upstream_package_source = true
+        $manage_epel = true
+      } elsif $::operatingsystem == 'Amazon' {
+        $package_name = 'docker'
+        $use_upstream_package_source = false
+        $manage_epel = false
       } else {
-        $package_name   = 'docker'
-        $use_upstream_package_source = false
+        $package_name = $package_name_default
+        $use_upstream_package_source = true
+        $manage_epel = false
       }
-      $package_source_location = ''
-      $service_name   = $service_name_default
+      $package_key_source = 'https://yum.dockerproject.org/gpg'
+      if $::operatingsystem == 'Fedora' {
+        $package_source_location = "https://yum.dockerproject.org/repo/main/fedora/${::operatingsystemmajrelease}"
+      } else {
+        $package_source_location = "https://yum.dockerproject.org/repo/main/centos/${::operatingsystemmajrelease}"
+      }
+      $package_key = undef
+      $package_repos = undef
+      $package_release = undef
+      $service_name = $service_name_default
       $docker_command = $docker_command_default
       if versioncmp($::operatingsystemrelease, '7.0') < 0 {
         $detach_service_in_init = true
@@ -80,7 +100,11 @@ class docker::params {
         }
       } else {
         $detach_service_in_init = false
-        $docker_group = 'dockerroot'
+        if $use_upstream_package_source {
+          $docker_group = $docker_group_default
+        } else {
+          $docker_group = 'dockerroot'
+        }
         include docker::systemd_reload
       }
 
@@ -101,27 +125,40 @@ class docker::params {
       } else {
         $repo_opt = undef
       }
-      if $::kernelversion == '2.6.32' { $nowarn_kernel = true }
-      else { $nowarn_kernel = false }
+      if $::kernelversion == '2.6.32' {
+        $nowarn_kernel = true
+      } else {
+        $nowarn_kernel = false
+      }
     }
     'Archlinux' : {
+      include docker::systemd_reload
+      $manage_epel = false
       $docker_group = $docker_group_default
-      $package_source_location     = ''
+      $package_key_source = undef
+      $package_source_location = undef
+      $package_key = undef
+      $package_repos = undef
+      $package_release = undef
       $use_upstream_package_source = false
-      $package_name   = 'docker'
-      $service_name   = $service_name_default
+      $package_name = 'docker'
+      $service_name = $service_name_default
       $docker_command = $docker_command_default
       $detach_service_in_init = false
-      include docker::systemd_reload
       $repo_opt = undef
       $nowarn_kernel = false
     }
     default: {
+      $manage_epel = false
       $docker_group = $docker_group_default
-      $package_source_location     = ''
+      $package_key_source = undef
+      $package_source_location = undef
+      $package_key = undef
+      $package_repos = undef
+      $package_release = undef
       $use_upstream_package_source = true
-      $package_name   = $package_name_default
-      $service_name   = $service_name_default
+      $package_name = $package_name_default
+      $service_name = $service_name_default
       $docker_command = $docker_command_default
       $detach_service_in_init = true
       $repo_opt = undef
@@ -134,8 +171,8 @@ class docker::params {
   # https://github.com/docker/docker/issues/4734
   $prerequired_packages = $::osfamily ? {
     'Debian' => $::operatingsystem ? {
-      'Debian' => ['apt-transport-https', 'cgroupfs-mount'],
-      'Ubuntu' => ['apt-transport-https', 'cgroup-lite', 'apparmor'],
+      'Debian' => ['cgroupfs-mount'],
+      'Ubuntu' => ['cgroup-lite', 'apparmor'],
       default  => [],
     },
     'RedHat' => ['device-mapper'],

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -1,0 +1,55 @@
+# == Class: docker::repos
+#
+#
+class docker::repos {
+
+  ensure_packages($docker::prerequired_packages)
+
+  case $::osfamily {
+    'Debian': {
+      include apt
+      # apt-transport-https is required by the apt to get the sources
+      ensure_packages('apt-transport-https')
+      Package['apt-transport-https'] -> Apt::Source <||>
+      if $::operatingsystem == 'Debian' and $::lsbdistcodename == 'wheezy' {
+        include apt::backports
+      }
+      Apt::Source <||> ~> Exec['apt_update'] -> Package[$docker::prerequired_packages]
+      if ($docker::use_upstream_package_source) {
+        apt::source { 'docker':
+          location          => $docker::package_source_location,
+          release           => $docker::package_release,
+          repos             => $docker::package_repos,
+          key               => $docker::package_key,
+          key_source        => $docker::package_key_source,
+          required_packages => 'debian-keyring debian-archive-keyring',
+          pin               => '10',
+          include_src       => false,
+        }
+        if $docker::manage_package {
+          Apt::Source['docker'] -> Package['docker']
+        }
+      }
+
+    }
+    'RedHat': {
+      if $docker::manage_package {
+        if ($docker::use_upstream_package_source) {
+          yumrepo { 'docker':
+            baseurl  => $docker::package_source_location,
+            gpgkey   => $docker::package_key_source,
+            gpgcheck => true,
+          }
+          Yumrepo['docker'] -> Package['docker']
+        }
+
+        if ($::operatingsystem != 'Amazon') and ($::operatingsystem != 'Fedora') {
+          if ($docker::manage_epel == true) {
+            include 'epel'
+            Class['epel'] -> Package['docker']
+          }
+        }
+      }
+    }
+  }
+}

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -14,7 +14,7 @@ class docker::repos {
       if $::operatingsystem == 'Debian' and $::lsbdistcodename == 'wheezy' {
         include apt::backports
       }
-      Apt::Source <||> ~> Exec['apt_update'] -> Package[$docker::prerequired_packages]
+      Exec['apt_update'] -> Package[$docker::prerequired_packages]
       if ($docker::use_upstream_package_source) {
         apt::source { 'docker':
           location          => $docker::package_source_location,

--- a/metadata.json
+++ b/metadata.json
@@ -26,6 +26,11 @@
         "14.04"
       ]
     },{
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "7.8"
+      ]
+    },{
       "operatingsystem": "Archlinux"
     },{
       "operatingsystem": "Fedora",

--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -1,16 +1,7 @@
 require 'spec_helper_acceptance'
 
 describe 'docker' do
-  case fact('osfamily')
-  when 'RedHat'
-    package_name = if fact('operatingsystemrelease').to_f >= 7
-      'docker'
-    else
-      'docker-io'
-    end
-  else
-    package_name = 'lxc-docker'
-  end
+  package_name = 'docker-engine'
   service_name = 'docker'
   command = 'docker'
 
@@ -19,10 +10,13 @@ describe 'docker' do
     shell('sudo yum install -y device-mapper', :pty=>true) if fact('osfamily') == 'RedHat'
   end
 
+  context 'null' do
+  end
+
   context 'with default parameters' do
     let(:pp) {"
         class { 'docker':
-          docker_users => [ 'testuser' ]
+          docker_users => [ 'testuser' ],
         }
         docker::image { 'nginx': }
         docker::run { 'nginx':
@@ -105,7 +99,7 @@ describe 'docker' do
       registry_port = 5000
       @registry_address = "#{registry_host}:#{registry_port}"
       @registry_email = 'user@example.com'
-      @config_file = fact('osfamily') == 'RedHat' ? '~/.dockercfg' : '~/.docker/config.json'
+      @config_file = '~/.docker/config.json'
       @manifest = <<-EOS
         class { 'docker': }
         docker::run { 'registry':

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   centos-66-x64:
     roles:
-      - master
+      - default
     platform: el-6-x86_64
     box: puppetlabs/centos-6.6-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm

--- a/spec/acceptance/nodesets/centos-70-x64.yml
+++ b/spec/acceptance/nodesets/centos-70-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   centos-70-x64:
     roles:
-      - master
+      - default
     platform: el-7-x86_64
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm

--- a/spec/acceptance/nodesets/debian-78-x64.yml
+++ b/spec/acceptance/nodesets/debian-78-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
   debian-78-x64:
     roles:
-      - master
+      - default
     platform: debian-7-amd64
     box: puppetlabs/debian-7.8-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/debian-7.8-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  color: false

--- a/spec/acceptance/nodesets/debian-81-x64.yml
+++ b/spec/acceptance/nodesets/debian-81-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  debian-81-x64:
+    roles:
+      - default
+    platform: debian-8-amd64
+    box: debian/jessie64
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss
+  color: false

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,7 +1,7 @@
 HOSTS:
-  ubuntu-server-1404-x64:
+  ubuntu-1404-x64:
     roles:
-      - master
+      - default
     platform: ubuntu-14.04-amd64
     box: puppetlabs/ubuntu-14.04-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  color: false

--- a/spec/acceptance/nodesets/ubuntu-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-12042-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
-  ubuntu-server-12042-x64:
+  ubuntu-12042-x64:
     roles:
-      - master
+      - default
     platform: ubuntu-12.04-amd64
     box: ubuntu-server-12042-x64-vbox4210-nocm
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box

--- a/spec/acceptance/nodesets/ubuntu-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-x64.yml
@@ -1,7 +1,7 @@
 HOSTS:
-  ubuntu-server-1404-x64:
+  ubuntu-1404-x64:
     roles:
-      - master
+      - default
     platform: ubuntu-14.04-amd64
     box: puppetlabs/ubuntu-14.04-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm

--- a/spec/acceptance/nodesets/ubuntu-1504-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1504-x64.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-1404-x64:
+    roles:
+      - default
+    platform: ubuntu-15.04-amd64
+    box: ubuntu/vivid64
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss
+  color: false

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -18,21 +18,21 @@ describe 'docker', :type => :class do
 
         it { should contain_service('docker').with_hasrestart('false') }
         it { should contain_class('apt') }
-        it { should contain_package('apt-transport-https').that_comes_before('Package[docker]') }
-        it { should contain_package('docker').with_name('lxc-docker').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('https://get.docker.com/ubuntu') }
+        it { should contain_package('apt-transport-https').that_comes_before('Apt::Source[docker]') }
+        it { should contain_package('docker').with_name('docker-engine').with_ensure('present') }
+        it { should contain_apt__source('docker').with_location('https://apt.dockerproject.org/repo') }
         it { should contain_file('/etc/init.d/docker').with_ensure('link').with_target('/lib/init/upstart-job') }
         it { should contain_package('docker').with_install_options(nil) }
 
         context 'with a custom version' do
           let(:params) { {'version' => '0.5.5' } }
-          it { should contain_package('docker').with_name('lxc-docker-0.5.5').with_ensure('present') }
+          it { should contain_package('docker').with_name('docker-engine-0.5.5').with_ensure('present') }
         end
 
         context 'with no upstream package source' do
           let(:params) { {'use_upstream_package_source' => false } }
           it { should_not contain_apt__source('docker') }
-          it { should contain_package('docker').with_name('lxc-docker') }
+          it { should contain_package('docker').with_name('docker-engine') }
         end
 
         context 'with no upstream package source' do
@@ -100,6 +100,7 @@ describe 'docker', :type => :class do
       end
 
       it { should compile.with_all_deps }
+      it { should contain_class('docker::repos').that_comes_before('docker::install') }
       it { should contain_class('docker::install').that_comes_before('docker::config') }
       it { should contain_class('docker::service').that_subscribes_to('docker::config') }
       it { should contain_class('docker::config') }
@@ -315,7 +316,7 @@ describe 'docker', :type => :class do
     context 'with no upstream package source' do
       let(:params) { {'use_upstream_package_source' => false } }
       it { should_not contain_apt__source('docker') }
-      it { should contain_package('docker').with_name('docker.io') }
+      it { should contain_package('docker').with_name('docker-engine') }
     end
   end
 
@@ -327,18 +328,17 @@ describe 'docker', :type => :class do
     } }
 
     it { should contain_class('epel') }
+    it { should_not contain_yumrepo('docker') }
+
     context 'with no epel repo' do
       let(:params) { {'manage_epel' => false } }
       it { should_not contain_class('epel') }
     end
+
     it { should contain_package('docker').with_name('docker-io').with_ensure('present') }
     it { should_not contain_apt__source('docker') }
     it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
 
-    context 'with no upstream package source' do
-      let(:params) { {'use_upstream_package_source' => false } }
-      it { should_not contain_class('epel') }
-    end
   end
 
   context 'RedHat 6.5 with patched Docker kernel' do
@@ -368,7 +368,8 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '21.0'
     } }
 
-    it { should contain_package('docker').with_name('docker') }
+    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_yumrepo('docker') }
     it { should_not contain_class('epel') }
   end
 
@@ -380,7 +381,8 @@ describe 'docker', :type => :class do
       :operatingsystemmajrelease => '7',
     } }
 
-    it { should contain_package('docker').with_name('docker') }
+    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_yumrepo('docker') }
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=rhel7-extras') }
 
@@ -399,7 +401,7 @@ describe 'docker', :type => :class do
       :operatingsystemmajrelease => '7',
     } }
 
-    it { should contain_package('docker').with_name('docker') }
+    it { should contain_package('docker').with_name('docker-engine') }
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=ol7_addons') }
 
@@ -413,7 +415,7 @@ describe 'docker', :type => :class do
       :operatingsystemmajrelease => '7',
     } }
 
-    it { should contain_package('docker').with_name('docker') }
+    it { should contain_package('docker').with_name('docker-engine') }
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=sl-extras') }
 
@@ -444,7 +446,7 @@ describe 'docker', :type => :class do
       :kernelrelease          => '3.8.0-29-generic'
     } }
     it { should contain_service('docker').with_provider('upstart') }
-    it { should contain_package('docker').with_name('lxc-docker').with_ensure('present')  }
+    it { should contain_package('docker').with_name('docker-engine').with_ensure('present')  }
     it { should contain_package('apparmor') }
   end
 

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -10,7 +10,7 @@ require 'spec_helper'
 
     if osfamily == 'Debian'
       initscript = '/etc/init.d/docker-sample'
-      command = 'docker.io'
+      command = 'docker'
       systemd = false
     elsif osfamily == 'Archlinux'
       initscript = '/etc/systemd/system/docker-sample.service'


### PR DESCRIPTION
The apt module already has a dependency like this, and having this
creates a dependency cycle with puppetlabs/apt 1.8.0

```
Error: Could not apply complete catalog: Found 1 dependency cycle:
(Anchor[apt::source::docker] => Apt::Source[docker] => Exec[apt_update] => Class[Apt::Update] => Anchor[apt::source::docker])
```