### PR TITLE
Made version parameter work on yum based OSs

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,7 @@ class docker::install {
   validate_bool($docker::use_upstream_package_source)
 
   ensure_packages($docker::prerequired_packages)
-
+  $ensure = $docker::ensure
   case $::osfamily {
     'Debian': {
       if $docker::manage_package {
@@ -36,8 +36,6 @@ class docker::install {
       } else {
         if $docker::version and $docker::ensure != 'absent' {
           $ensure = $docker::version
-        } else {
-          $ensure = $docker::ensure
         }
       }
 
@@ -81,6 +79,9 @@ class docker::install {
           }
         }
       }
+      if $docker::version and $docker::ensure != 'absent' {
+          $ensure = $docker::version
+      }
     }
     'Archlinux': {
       $manage_kernel = false
@@ -102,7 +103,7 @@ class docker::install {
     }
   }
 
-  if $docker::version {
+  if $docker::version and $::osfamily != 'RedHat' {
     $dockerpackage = "${docker::package_name}-${docker::version}"
   } else {
     $dockerpackage = $docker::package_name
@@ -111,13 +112,13 @@ class docker::install {
   if $docker::manage_package {
     if $docker::repo_opt {
       package { 'docker':
-        ensure          => $docker::ensure,
+        ensure          => $ensure,
         name            => $dockerpackage,
         install_options => $docker::repo_opt,
       }
     } else {
         package { 'docker':
-          ensure => $docker::ensure,
+          ensure => $ensure,
           name   => $dockerpackage,
         }
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -85,7 +85,7 @@ class docker::install {
       if $docker::version and $docker::ensure != 'absent' {
         $ensure = $docker::version
       } else {
-        $ensure = $docker::ensure  
+        $ensure = $docker::ensure
       }
     }
     'Archlinux': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,9 +33,12 @@ class docker::install {
         if $docker::manage_package {
           Apt::Source['docker'] -> Package['docker']
         }
+        $ensure = $docker::ensure
       } else {
         if $docker::version and $docker::ensure != 'absent' {
           $ensure = $docker::version
+        } else {
+          $ensure = $docker::ensure
         }
       }
 
@@ -80,12 +83,14 @@ class docker::install {
         }
       }
       if $docker::version and $docker::ensure != 'absent' {
-          $ensure = $docker::version
+        $ensure = $docker::version
+      } else {
+        $ensure = $docker::ensure  
       }
     }
     'Archlinux': {
       $manage_kernel = false
-
+      $ensure = $docker::ensure
       if $docker::version {
         notify { 'docker::version unsupported on Archlinux':
           message => 'Versions other than latest are not supported on Arch Linux. This setting will be ignored.'


### PR DESCRIPTION
Version parameter was being appended to the package name rather than to the ensure which did not work on CentOS7 and presumably other yum based OS