### PR TITLE
Fix spec for platforms with docker 1.7

### DIFF
--- a/spec/acceptance/docker_spec.rb
+++ b/spec/acceptance/docker_spec.rb
@@ -105,7 +105,7 @@ describe 'docker' do
       registry_port = 5000
       @registry_address = "#{registry_host}:#{registry_port}"
       @registry_email = 'user@example.com'
-      @config_file = fact('osfamily') == 'RedHat' ? '~/.dockercfg' : '~/.docker/config.json'
+      @config_file = shell('docker --version|cut -d"/" -f2') > "1.7" ? '~/.dockercfg' : '~/.docker/config.json'
       @manifest = <<-EOS
         class { 'docker': }
         docker::run { 'registry':


### PR DESCRIPTION
Docker 1.7 moved the configuration from ~/.dockercfg to
~/.docker/config.json and this is now the version available on CentOS 7.
This change checks the docker version rather than the operating system
so that the check is not bound to the platform.