### PR TITLE
fix overlay vs. overlayfs in storage_driver regex

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,7 +204,7 @@ class docker(
   }
 
   if $storage_driver {
-    validate_re($storage_driver, '^(aufs|devicemapper|btrfs|overlay|vfs)$', 'Valid values for storage_driver are aufs, devicemapper, btrfs, overlayfs, vfs.' )
+    validate_re($storage_driver, '^(aufs|devicemapper|btrfs|overlayfs|vfs)$', 'Valid values for storage_driver are aufs, devicemapper, btrfs, overlayfs, vfs.' )
   }
 
   if $dm_fs {


### PR DESCRIPTION
The regex was validating for `overlay` but the documentation says that `overlayfs` is correct.