### PR TITLE
Make it work for jessie

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,9 +45,15 @@ class docker::params {
           $docker_command = $docker_command_default
         }
         default: {
-          $package_name   = 'docker.io'
-          $service_name   = 'docker.io'
-          $docker_command = 'docker.io'
+          if ($::lsbdistcodename == 'jessie') {
+            $package_name   = 'docker.io'
+            $service_name   = 'docker'
+            $docker_command = 'docker'
+          } else {
+            $package_name   = 'docker.io'
+            $service_name   = 'docker.io'
+            $docker_command = 'docker.io'
+          }
         }
       }
       $docker_group = $docker_group_default

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -319,6 +319,27 @@ describe 'docker', :type => :class do
     end
   end
 
+  context 'specific to Debian jessie' do
+    let(:facts) { {
+      :osfamily        => 'Debian',
+      :operatingsystem => 'Debian',
+      :lsbdistid       => 'Debian',
+      :lsbdistcodename => 'jessie',
+      :kernelrelease   => '3.16.0-4-amd64'
+    } }
+
+    it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
+    it { should_not contain_package('linux-image-generic-lts-raring') }
+    it { should_not contain_package('linux-headers-generic-lts-raring') }
+    it { should contain_service('docker').without_provider }
+
+    context 'with no upstream package source' do
+      let(:params) { {'use_upstream_package_source' => false } }
+      it { should_not contain_apt__source('docker') }
+      it { should contain_package('docker').with_name('docker.io') }
+    end
+  end
+
   context 'specific to RedHat' do
     let(:facts) { {
       :osfamily => 'RedHat',

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -1,8 +1,37 @@
 require 'spec_helper'
 
+
 describe 'docker::image', :type => :define do
   let(:title) { 'base' }
   it { should contain_exec('docker pull base') }
+
+  context 'specific to Debian jessie' do
+    let(:facts) { {
+      :osfamily        => 'Debian',
+      :operatingsystem => 'Debian',
+      :lsbdistid       => 'Debian',
+      :lsbdistcodename => 'jessie',
+    } }
+
+    context 'with docker_file => Dockerfile' do
+      let(:params) { { 'docker_file' => 'Dockerfile' }}
+      it { should contain_exec('docker build -t base - < Dockerfile') }
+    end
+  end
+
+  context 'specific to Debian wheezy' do
+    let(:facts) { {
+      :osfamily        => 'Debian',
+      :operatingsystem => 'Debian',
+      :lsbdistid       => 'Debian',
+      :lsbdistcodename => 'wheezy',
+    } }
+
+    context 'with docker_file => Dockerfile' do
+      let(:params) { { 'docker_file' => 'Dockerfile' }}
+      it { should contain_exec('docker.io build -t base - < Dockerfile') }
+    end
+  end
 
   context 'with ensure => absent' do
     let(:params) { { 'ensure' => 'absent' } }


### PR DESCRIPTION
According to /usr/share/doc/docker.io/changelog.Debian.gz the bin/docker.io symlink was removed with docker 1.3.1

As I think few people want to install docker < 1.3.1 on debian jessie, I used jessie to reflect this change.

Now your find puppet module works fine for me under jessie!