### PR TITLE
Moved shell_values outside of OPTIONS

### DIFF
--- a/templates/etc/sysconfig/docker.rhel7.erb
+++ b/templates/etc/sysconfig/docker.rhel7.erb
@@ -10,11 +10,11 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
-<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
-<% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>"
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>"
 
 <% if @proxy %>http_proxy='<%= @proxy %>'
   https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
 # TMPDIR="<%= @tmp_dir %>"
+<% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>


### PR DESCRIPTION
Adding anything to shell_values causes it to be appended to the docker daemon options.  This fixes that by replicating what was done for docker.erb.