### PR TITLE
Adding support for unless within a docker exec type

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ Docker also supports running arbitrary commands within the context of a
 running container. And now so does the Puppet module.
 
 ```puppet
-docker::exec { 'bin/echo root >> /usr/lib/cron/cron.allow':
+docker::exec { 'cron_allow_root':
   detach       => true,
-  container    => 'helloworld',
-  command      => 'uptime',
+  container    => 'mycontainer',
+  command      => '/bin/echo root >> /usr/lib/cron/cron.allow',
   tty          => true,
   unless       => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
 }

--- a/README.md
+++ b/README.md
@@ -283,15 +283,16 @@ docker::registry_auth::registries:
 
 ### Exec
 
-Docker also supports running arbitrary comments within the context of a
+Docker also supports running arbitrary commands within the context of a
 running container. And now so does the Puppet module.
 
 ```puppet
-docker::exec { 'helloworld-uptime':
-  detach    => true,
-  container => 'helloworld',
-  command   => 'uptime',
-  tty       => true,
+docker::exec { 'bin/echo root >> /usr/lib/cron/cron.allow':
+  detach       => true,
+  container    => 'helloworld',
+  command      => 'uptime',
+  tty          => true,
+  unless       => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
 }
 ```
 

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -1,4 +1,4 @@
-# == Define: docker:exec
+
 #
 # A define which executes a command inside a container.
 #
@@ -18,6 +18,7 @@ define docker::exec(
 
   validate_string($container)
   validate_string($command)
+  validate_string($unless)
   validate_bool($detach)
   validate_bool($interactive)
   validate_bool($tty)
@@ -35,7 +36,11 @@ define docker::exec(
     $sanitised_container = $container
   }
   $exec = "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${command}"
-  $unless_command = "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${unless}"
+  $unless_command = $unless ? {
+      undef              => undef,
+      ''                 => undef,
+      default            => "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${unless}",
+  }
 
   exec { $exec:
     environment => 'HOME=/root',

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -8,6 +8,7 @@ define docker::exec(
   $tty = false,
   $container = undef,
   $command = undef,
+  $unless = undef,
   $sanitise_name = true,
 ) {
   include docker::params
@@ -34,10 +35,12 @@ define docker::exec(
     $sanitised_container = $container
   }
   $exec = "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${command}"
+  $unless_command = "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${unless}"
 
   exec { $exec:
     environment => 'HOME=/root',
     path        => ['/bin', '/usr/bin'],
     timeout     => 0,
+    unless      => $unless_command,
   }
 }

--- a/spec/defines/exec_spec.rb
+++ b/spec/defines/exec_spec.rb
@@ -23,4 +23,8 @@ describe 'docker::exec', :type => :define do
       it { should contain_exec('docker exec --interactive=true container command').with_unless ('docker exec --interactive=true container some_command arg1') }
   end
 
+  context 'when running without unless' do
+      let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true,} }
+      it { should contain_exec('docker exec --interactive=true container command').with_unless (nil) }
+  end
 end

--- a/spec/defines/exec_spec.rb
+++ b/spec/defines/exec_spec.rb
@@ -17,4 +17,10 @@ describe 'docker::exec', :type => :define do
       let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true} }
       it { should contain_exec('docker exec --interactive=true container command') }
   end
+
+  context 'when running with unless' do
+      let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true, 'unless' => 'some_command arg1'} }
+      it { should contain_exec('docker exec --interactive=true container command').with_unless ('docker exec --interactive=true container some_command arg1') }
+  end
+
 end


### PR DESCRIPTION
Currently there doesn't appear to be a way to run a docker exec command if some kind of state doesn't exist. This commit introduces support for this.