### PR TITLE
Use new apt.dockerproject.org repository

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class docker::params {
         }
       }
       $docker_group = $docker_group_default
-      $package_source_location     = 'https://get.docker.com/ubuntu'
+      $package_source_location     = 'http://apt.dockerproject.org/repo/'
       $use_upstream_package_source = true
       $detach_service_in_init = true
       $repo_opt = undef

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -20,7 +20,7 @@ describe 'docker', :type => :class do
         it { should contain_class('apt') }
         it { should contain_package('apt-transport-https').that_comes_before('Package[docker]') }
         it { should contain_package('docker').with_name('lxc-docker').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('https://get.docker.com/ubuntu') }
+        it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo/') }
         it { should contain_file('/etc/init.d/docker').with_ensure('link').with_target('/lib/init/upstart-job') }
         it { should contain_package('docker').with_install_options(nil) }
 


### PR DESCRIPTION
A new repository has been put in place for docker, this module should probably use it. See https://blog.docker.com/2015/07/new-apt-and-yum-repos/ for details.

Note that there is also a RPM repository, so similar changes might be needed for the RedHat part...

This fixes #345.