### PR TITLE
New docker repos

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class docker::params {
       $service_name = $service_name_default
       $docker_command = $docker_command_default
       $docker_group = $docker_group_default
-      $package_source_location = 'https://apt.dockerproject.org/repo'
+      $package_source_location = 'http://apt.dockerproject.org/repo'
       $package_key_source = 'https://apt.dockerproject.org/gpg'
       $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
       $package_repos = 'main'

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -8,11 +8,6 @@ class docker::repos {
   case $::osfamily {
     'Debian': {
       include apt
-      if $docker::package_source_location ~= "^https:.*" { 
-        # apt-transport-https is required by the apt to get the sources, if the source is HTTPS
-        ensure_packages('apt-transport-https')
-        Package['apt-transport-https'] -> Apt::Source <||>
-      }
       if $::operatingsystem == 'Debian' and $::lsbdistcodename == 'wheezy' {
         include apt::backports
       }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -8,9 +8,11 @@ class docker::repos {
   case $::osfamily {
     'Debian': {
       include apt
-      # apt-transport-https is required by the apt to get the sources
-      ensure_packages('apt-transport-https')
-      Package['apt-transport-https'] -> Apt::Source <||>
+      if $docker::package_source_location ~= "^https:.*" { 
+        # apt-transport-https is required by the apt to get the sources, if the source is HTTPS
+        ensure_packages('apt-transport-https')
+        Package['apt-transport-https'] -> Apt::Source <||>
+      }
       if $::operatingsystem == 'Debian' and $::lsbdistcodename == 'wheezy' {
         include apt::backports
       }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -18,7 +18,6 @@ describe 'docker', :type => :class do
         storage_config_file = '/etc/default/docker'
 
         context 'It should include default prerequired_packages' do
-          it { should contain_package('apt-transport-https').with_ensure('present') }
           it { should contain_package('cgroupfs-mount').with_ensure('present') }
         end
       end
@@ -39,7 +38,6 @@ describe 'docker', :type => :class do
         it { should contain_file('/etc/init.d/docker').with_ensure('link').with_target('/lib/init/upstart-job') }
 
         context 'It should include default prerequired_packages' do
-          it { should contain_package('apt-transport-https').with_ensure('present') }
           it { should contain_package('cgroup-lite').with_ensure('present') }
           it { should contain_package('apparmor').with_ensure('present') }
         end
@@ -48,9 +46,8 @@ describe 'docker', :type => :class do
       if osfamily == 'Ubuntu' or osfamily == 'Debian'
 
         it { should contain_class('apt') }
-        it { should contain_package('apt-transport-https').that_comes_before('Apt::Source[docker]') }
         it { should contain_package('docker').with_name('docker-engine').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('https://apt.dockerproject.org/repo') }
+        it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo') }
         it { should contain_package('docker').with_install_options(nil) }
 
         context 'with a custom version' do


### PR DESCRIPTION
Changed repo url to use plain HTTP (to enable caching on apt-cacher ng). Also removed requirement for apt-transport-https, since it's not needed anymore (and created dependency loop with puppet 3.7.2)