### PR TITLE
Add a new $local_user param to the registry login

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -22,13 +22,18 @@
 #   Email for registration to private Docker registry. Leave undef if
 #   auth is not required.
 #
+# [*local_user*]
+#   The local user to log in as. Docker will store credentials in this
+#   users home directory
+#
 #
 define docker::registry(
-  $server    = $title,
-  $ensure    = 'present',
-  $username  = undef,
-  $password  = undef,
-  $email     = undef,
+  $server      = $title,
+  $ensure      = 'present',
+  $username    = undef,
+  $password    = undef,
+  $email       = undef,
+  $local_user  = 'root',
 ) {
   include docker::params
 
@@ -50,7 +55,7 @@ define docker::registry(
 
   exec { "auth against ${server}":
     command => $auth_cmd,
-    user    => 0,
+    user    => $local_user,
     cwd     => '/root',
     path    => ['/bin', '/usr/bin'],
     timeout => 0,

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -39,6 +39,11 @@ describe 'docker::registry', :type => :define do
     it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000") }
   end
 
+  context 'with username => user1, and password => secret, and email => user1@example.io and local_user => testuser' do
+    let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'local_user' => 'testuser' } }
+    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000").with_user('testuser') }
+  end
+
   context 'with an invalid ensure value' do
     let(:params) { { 'ensure' => 'not present or absent' } }
     it do


### PR DESCRIPTION
Currently we login to registries as root. This works but breaks the
expectation that anyone in the docker group should be able to use these
registries. This patch exposes a $local_user param which lets us exec as
any user and consumers of this module can specify that in their
manifests.