### PR TITLE
Use environment variable for registry password.

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -43,7 +43,8 @@ define docker::registry(
 
   if $ensure == 'present' {
     if $username != undef and $password != undef and $email != undef {
-      $auth_cmd = "${docker_command} login -u '${username}' -p '${password}' -e '${email}' ${server}"
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" -e '${email}' ${server}"
+      $auth_environment = "password=${password}"
     }
     else {
       $auth_cmd = "${docker_command} login ${server}"
@@ -54,11 +55,12 @@ define docker::registry(
   }
 
   exec { "auth against ${server}":
-    command => $auth_cmd,
-    user    => $local_user,
-    cwd     => '/root',
-    path    => ['/bin', '/usr/bin'],
-    timeout => 0,
+    environment => $auth_environment,
+    command     => $auth_cmd,
+    user        => $local_user,
+    cwd         => '/root',
+    path        => ['/bin', '/usr/bin'],
+    timeout     => 0,
   }
 
 }

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -31,17 +31,17 @@ describe 'docker::registry', :type => :define do
 
   context 'with ensure => present and username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000") }
+    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
   end
 
   context 'with username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000") }
+    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
   end
 
   context 'with username => user1, and password => secret, and email => user1@example.io and local_user => testuser' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'local_user' => 'testuser' } }
-    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p 'secret' -e 'user1@example.io' localhost:5000").with_user('testuser') }
+    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_user('testuser').with_environment('password=secret') }
   end
 
   context 'with an invalid ensure value' do


### PR DESCRIPTION
I'm using eyaml to encrypt a private docker registry password in a hiera xxx.eyaml file, but if puppet apply is run with --debug, the exec task in docker::registry (auth against ${server}) logs the password in plain text.

This change just puts the password into an environment variable for the exec task, so the logs show '-p ${password}' instead.
