### PR TITLE
Fix ensure_packages argument

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -9,7 +9,7 @@ class docker::repos {
     'Debian': {
       include apt
       # apt-transport-https is required by the apt to get the sources
-      ensure_packages('apt-transport-https')
+      ensure_packages(['apt-transport-https'])
       Package['apt-transport-https'] -> Apt::Source <||>
       if $::operatingsystem == 'Debian' and $::lsbdistcodename == 'wheezy' {
         include apt::backports


### PR DESCRIPTION
This encloses the argument to `ensure_packages` in an array. Previously, a string was being passed, which results in this error:

```
Error: ensure_packages(): Requires array given (String) at ....../modules/docker/manifests/repos.pp:12
```

Documentation for `ensure_packages`: https://forge.puppetlabs.com/puppetlabs/stdlib#ensure_packages

I'm curious to know whether or not this has been a problem for anyone else too.