### PR TITLE
Don't fail the service when the pull doesn't work

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -14,7 +14,7 @@ TimeoutStartSec=0
 Environment="HOME=/root"
 ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 ExecStartPre=-/usr/bin/<%= @docker_command %> rm <%= @sanitised_title %>
-<%- if @pull_on_start %>ExecStartPre=/usr/bin/<%= @docker_command %> pull <%= @image %>
+<%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
 ExecStart=/usr/bin/<%= @docker_command %> run \
         <%= @docker_run_flags %> \


### PR DESCRIPTION
The image may very well be available locally, and you don't want to
end up with services not starting because of network issues or the like