### PR TITLE
allow Docker::Image to be refreshed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Puppet module for installing, configuring and managing
 [Docker](https://github.com/docker/docker) from the [official repository](http://docs.docker.com/installation/) or alternatively from [EPEL on RedHat](http://docs.docker.io/en/latest/installation/rhel/) based distributions.
- 
+
 [![Puppet
 Forge](http://img.shields.io/puppetforge/v/garethr/docker.svg)](https://forge.puppetlabs.com/garethr/docker) [![Build
 Status](https://secure.travis-ci.org/garethr/garethr-docker.png)](http://travis-ci.org/garethr/garethr-docker) [![Documentation
@@ -182,6 +182,20 @@ docker::image { 'ubuntu':
 }
 ```
 
+You can trigger a rebuild of the image by subscribing to external events like Dockerfile changes:
+
+```puppet
+docker::image { 'ubuntu':
+  docker_file => '/tmp/Dockerfile'
+  subscribe => File['/tmp/Dockerfile'],
+}
+
+file { '/tmp/Dockerfile':
+  ensure => file,
+  source => 'puppet:///modules/someModule/Dockerfile',
+}
+```
+
 You can also remove images you no longer need with:
 
 ```puppet
@@ -202,6 +216,7 @@ docker::images:
   ubuntu:
     image_tag: 'precise'
 ```
+
 
 ### Containers
 

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -87,7 +87,7 @@ define docker::image(
     }
   } else {
     exec { "check_image_${image}_install":
-      command => "true",
+      command => 'echo > /dev/null',
       path    => ['/bin', '/usr/bin'],
       unless  => $image_find,
       notify  => Exec[$image_install],

--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -86,11 +86,18 @@ define docker::image(
       timeout     => 0,
     }
   } else {
+    exec { "check_image_${image}_install":
+      command => "true",
+      path    => ['/bin', '/usr/bin'],
+      unless  => $image_find,
+      notify  => Exec[$image_install],
+    }
+
     exec { $image_install:
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
-      unless      => $image_find,
       timeout     => 0,
+      refreshonly => true,
     }
   }
 }


### PR DESCRIPTION
I introduced another "exec" so that the "$image_install" can be triggered by external resources. The new "exec" checks if the image already exists and triggers the install if necessary. So the image is built if it does not exist or if it is refreshed externally.

With this change I can specify a "Dockerfile" resource that triggers the image on change.

