### PR TITLE
Fix Docker systemd deprecated cli options

### DIFF
--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,5 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> -d -H fd:// $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_command %> daemon -H fd:// $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -3,7 +3,7 @@ EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> -d -H fd:// $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_command %> daemon -H fd:// $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
Fix the systemd daemon flag in debian and rhel templates that became
broken due to the recent Docker upstream commit

https://github.com/docker/docker/commit/7929888214741c4ab194c44e0b14ac08aca06556