### PR TITLE
Extend service dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ docker::run { 'helloworld':
   privileged      => false,
   pull_on_start   => false,
   before_stop     => 'echo "So Long, and Thanks for All the Fish"',
+  after           => [ 'container_b', 'mysql' ],
   depends         => [ 'container_a', 'postgres' ],
 }
 ```
@@ -252,7 +253,9 @@ Specifying `pull_on_start` will pull the image before each time it is started.
 
 Specifying `before_stop` will execute a command before stopping the container.
 
-The `depends` option allows expressing containers that must be started before. This affects the generation of the init.d/systemd script.
+The `after` option allows expressing containers that must be started before. This affects the generation of the init.d/systemd script.
+
+The `depends` option allows expressing container dependencies. The depended container will be started before this container(s), and this container will be stopped before the depended container(s). This affects the generation of the init.d/systemd script.
 
 The service file created for systemd based systems enables automatic restarting of the service on failure by default.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Puppet module for installing, configuring and managing
 [Docker](https://github.com/docker/docker) from the [official repository](http://docs.docker.com/installation/) or alternatively from [EPEL on RedHat](http://docs.docker.io/en/latest/installation/rhel/) based distributions.
- 
+
 [![Puppet
 Forge](http://img.shields.io/puppetforge/v/garethr/docker.svg)](https://forge.puppetlabs.com/garethr/docker) [![Build
 Status](https://secure.travis-ci.org/garethr/garethr-docker.png)](http://travis-ci.org/garethr/garethr-docker) [![Documentation
@@ -255,7 +255,7 @@ Specifying `before_stop` will execute a command before stopping the container.
 
 The `after` option allows expressing containers that must be started before. This affects the generation of the init.d/systemd script.
 
-The `depends` option allows expressing container dependencies. The depended container will be started before this container(s), and this container will be stopped before the depended container(s). This affects the generation of the init.d/systemd script.
+The `depends` option allows expressing container dependencies. The depended container will be started before this container(s), and this container will be stopped before the depended container(s). This affects the generation of the init.d/systemd script. You can use `depend_services` to specify dependency for generic services (non-docker) that should be started before this container.
 
 The service file created for systemd based systems enables automatic restarting of the service on failure by default.
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -77,7 +77,7 @@ define docker::run(
   $after = [],
   $after_service = [],
   $depends = [],
-  $depends_service = [],
+  $depend_services = [],
   $tty = false,
   $socket_connect = [],
   $hostentries = [],
@@ -129,7 +129,7 @@ define docker::run(
   $extra_parameters_array = any2array($extra_parameters)
   $after_array = any2array($after)
   $depends_array = any2array($depends)
-  $depends_service_array = any2array($depends_service)
+  $depend_services_array = any2array($depend_services)
 
   $docker_run_flags = docker_run_flags({
     cpuset          => any2array($cpuset),

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -74,6 +74,7 @@ define docker::run(
   $extra_parameters = undef,
   $extra_systemd_parameters = {},
   $pull_on_start = false,
+  $after = [],
   $depends = [],
   $tty = false,
   $socket_connect = [],
@@ -123,6 +124,8 @@ define docker::run(
     $valid_detach = $detach
   }
 
+  $extra_parameters_array = any2array($extra_parameters)
+  $after_array = any2array($after)
   $depends_array = any2array($depends)
 
   $docker_run_flags = docker_run_flags({
@@ -157,6 +160,13 @@ define docker::run(
   }
   else {
     $sanitised_depends_array = regsubst($depends_array, '[^0-9A-Za-z.\-]', '-', 'G')
+  }
+
+  if empty($after_array) {
+    $sanitised_after_array = []
+  }
+  else {
+    $sanitised_after_array = regsubst($after_array, '[^0-9A-Za-z.\-]', '-', 'G')
   }
 
   if $restart {

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -75,7 +75,9 @@ define docker::run(
   $extra_systemd_parameters = {},
   $pull_on_start = false,
   $after = [],
+  $after_service = [],
   $depends = [],
+  $depends_service = [],
   $tty = false,
   $socket_connect = [],
   $hostentries = [],
@@ -127,6 +129,7 @@ define docker::run(
   $extra_parameters_array = any2array($extra_parameters)
   $after_array = any2array($after)
   $depends_array = any2array($depends)
+  $depends_service_array = any2array($depends_service)
 
   $docker_run_flags = docker_run_flags({
     cpuset          => any2array($cpuset),

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -45,6 +45,8 @@ require 'spec_helper'
       if (systemd)
         it { should contain_file(initscript).with_content(/After=.*\s+docker-foo.service/) }
         it { should contain_file(initscript).with_content(/After=.*\s+docker-bar.service/) }
+        it { should contain_file(initscript).with_content(/Wants=.*\s+docker-foo.service/) }
+        it { should contain_file(initscript).with_content(/Wants=.*\s+docker-bar.service/) }
       else
         it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
         it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -43,10 +43,10 @@ require 'spec_helper'
     context 'when passing `after` containers' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'after' => ['foo', 'bar']} }
       if (systemd)
-        it { should contain_file(initscript).with_content(/After=.*\s+docker-foo.service/) }
-        it { should contain_file(initscript).with_content(/After=.*\s+docker-bar.service/) }
-        it { should contain_file(initscript).with_content(/Wants=.*\s+docker-foo.service/) }
-        it { should contain_file(initscript).with_content(/Wants=.*\s+docker-bar.service/) }
+        it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-foo.service/) }
+        it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-bar.service/) }
+        it { should contain_file(initscript).with_content(/Wants=(.*\s+)?docker-foo.service/) }
+        it { should contain_file(initscript).with_content(/Wants=(.*\s+)?docker-bar.service/) }
       else
         it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
         it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }
@@ -56,10 +56,10 @@ require 'spec_helper'
     context 'when passing `depends` containers' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'depends' => ['foo', 'bar']} }
       if (systemd)
-        it { should contain_file(initscript).with_content(/After=.*\s+docker-foo.service/) }
-        it { should contain_file(initscript).with_content(/After=.*\s+docker-bar.service/) }
-        it { should contain_file(initscript).with_content(/Requires=.*\s+docker-foo.service/) }
-        it { should contain_file(initscript).with_content(/Requires=.*\s+docker-bar.service/) }
+        it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-foo.service/) }
+        it { should contain_file(initscript).with_content(/After=(.*\s+)?docker-bar.service/) }
+        it { should contain_file(initscript).with_content(/Requires=(.*\s+)?docker-foo.service/) }
+        it { should contain_file(initscript).with_content(/Requires=(.*\s+)?docker-bar.service/) }
       else
         it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
         it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -68,6 +68,21 @@ require 'spec_helper'
       end
     end
 
+    context 'when passing `depend_services`' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'depend_services' => ['foo', 'bar']} }
+      if (systemd)
+        it { should contain_file(initscript).with_content(/After=(.*\s+)?foo.service/) }
+        it { should contain_file(initscript).with_content(/After=(.*\s+)?bar.service/) }
+        it { should contain_file(initscript).with_content(/Requires=(.*\s+)?foo.service/) }
+        it { should contain_file(initscript).with_content(/Requires=(.*\s+)?bar.service/) }
+      else
+        it { should contain_file(initscript).with_content(/Required-Start:.*\s+foo/) }
+        it { should contain_file(initscript).with_content(/Required-Start:.*\s+bar/) }
+        it { should contain_file(initscript).with_content(/Required-Stop:.*\s+foo/) }
+        it { should contain_file(initscript).with_content(/Required-Stop:.*\s+bar/) }
+      end
+    end
+
     context 'with autorestart functionality' do
       let(:params) { {'command' => 'command', 'image' => 'base'} }
       if (systemd)

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -40,6 +40,17 @@ require 'spec_helper'
       end
     end
 
+    context 'when passing `after` containers' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'after' => ['foo', 'bar']} }
+      if (systemd)
+        it { should contain_file(initscript).with_content(/After=.*\s+docker-foo.service/) }
+        it { should contain_file(initscript).with_content(/After=.*\s+docker-bar.service/) }
+      else
+        it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
+        it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }
+      end
+    end
+
     context 'when passing `depends` containers' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'depends' => ['foo', 'bar']} }
       if (systemd)

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -2,11 +2,11 @@
 	@required_start = ["$network", "docker"] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}"} +
-		@depends_service_array
+		@depend_services_array
 
 	@required_stop = ["$network", "docker"] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}"} +
-		@depends_service_array
+		@depend_services_array
 -%>
 #!/bin/sh
 #

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -1,3 +1,13 @@
+<%-
+	@required_start = ["$network", "docker"] +
+		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}"} +
+		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}"} +
+		@depends_service_array
+
+	@required_stop = ["$network", "docker"] +
+		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}"} +
+		@depends_service_array
+-%>
 #!/bin/sh
 #
 # This file is managed by Puppet and local changes
@@ -12,8 +22,8 @@
 
 ### BEGIN INIT INFO
 # Provides:       <%= @service_prefix %><%= @sanitised_title %>
-# Required-Start: $network docker<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}" %><% end %><% end %><% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
-# Required-Stop: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
+# Required-Start: <%= @required_start.uniq.join(" ") %>
+# Required-Stop:  <%= @required_stop.uniq.join(" ") %>
 # Should-Start:
 # Should-Stop:
 # Default-Start: 2 3 4 5

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -12,7 +12,7 @@
 
 ### BEGIN INIT INFO
 # Provides:       <%= @service_prefix %><%= @sanitised_title %>
-# Required-Start: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
+# Required-Start: $network docker<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}" %><% end %><% end %><% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
 # Required-Stop: $network docker<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}" %><% end %><% end %>
 # Should-Start:
 # Should-Stop:

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -4,11 +4,11 @@
 [Unit]
 Description=Daemon for <%= @title %>
 After=docker.service
-After=<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}.service" %><% end %><% end %>
-After=<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
+<% if @after %>After=<%= @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}.join(" ") %><% end %>
+<% if @depends %>After=<%= @sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"}.join(" ") %><% end %>
 Requires=docker.service
-Requires=<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
-Wants=<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}.service" %><% end %><% end %>
+<% if @after %>Wants=<%= @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}.join(" ") %><% end %>
+<% if @depends %>Requires=<%= @sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"}.join(" ") %><% end %>
 
 [Service]
 Restart=on-failure

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -1,14 +1,21 @@
+<%-
+	@after = ["docker.service"] +
+		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
+		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
+		@depends_service_array.map{|s| "#{s}.service"}
+	@wants = @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}
+	@requires = ["docker.service"] +
+		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
+		@depends_service_array.map{|s| "#{s}.service"}
+-%>
 # This file is managed by Puppet and local changes
 # may be overwritten
 
 [Unit]
 Description=Daemon for <%= @title %>
-After=docker.service
-<% if @after %>After=<%= @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}.join(" ") %><% end %>
-<% if @depends %>After=<%= @sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"}.join(" ") %><% end %>
-Requires=docker.service
-<% if @after %>Wants=<%= @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}.join(" ") %><% end %>
-<% if @depends %>Requires=<%= @sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"}.join(" ") %><% end %>
+After=<%= @after.uniq.join(" ") %>
+Wants=<%= @wants.uniq.join(" ") %>
+Requires=<%= @requires.uniq.join(" ") %>
 
 [Service]
 Restart=on-failure

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -3,8 +3,12 @@
 
 [Unit]
 Description=Daemon for <%= @title %>
-After=docker.service<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}.service" %><% end %><% end %><% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
-Requires=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
+After=docker.service
+After=<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}.service" %><% end %><% end %>
+After=<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
+Requires=docker.service
+Requires=<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
+Wants=<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}.service" %><% end %><% end %>
 
 [Service]
 Restart=on-failure

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -3,7 +3,7 @@
 
 [Unit]
 Description=Daemon for <%= @title %>
-After=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
+After=docker.service<% if @after %><% @sanitised_after_array.each do |a| %><%= " #{@service_prefix}#{a}.service" %><% end %><% end %><% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
 Requires=docker.service<% if @depends %><% @sanitised_depends_array.each do |d| %><%= " #{@service_prefix}#{d}.service" %><% end %><% end %>
 
 [Service]

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -2,11 +2,11 @@
 	@after = ["docker.service"] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
-		@depends_service_array.map{|s| "#{s}.service"}
+		@depend_services_array.map{|s| "#{s}.service"}
 	@wants = @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}
 	@requires = ["docker.service"] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
-		@depends_service_array.map{|s| "#{s}.service"}
+		@depend_services_array.map{|s| "#{s}.service"}
 -%>
 # This file is managed by Puppet and local changes
 # may be overwritten


### PR DESCRIPTION
Cleanup dependencies:

* add extra parameter for non-docker-dependencies
* add 'after' parallel to 'depends' (includes and obsoletes #317)
  * after only implies order
  * depends implies two-way dependency
* calculate arrays beforehand and clean the code
