### PR TITLE
Added support for setting log-opt on service level

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -29,6 +29,7 @@ class docker::service (
   $log_level                         = $docker::log_level,
   $log_level                         = $docker::log_level,
   $log_driver                        = $docker::log_driver,
+  $log_opt                           = $docker::log_opt,
   $selinux_enabled                   = $docker::selinux_enabled,
   $socket_group                      = $docker::socket_group,
   $dns                               = $docker::dns,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -330,6 +330,22 @@ describe 'docker', :type => :class do
         end
       end
 
+      context 'with specific log_driver and log_opt' do
+        let(:params) {
+          { 'log_driver' => 'json-file',
+            'log_opt' => [ 'max-size=1m','max-file=3' ]
+          }
+        }
+        it { should contain_file(service_config_file).with_content(/--log-driver json-file/) }
+        it { should contain_file(service_config_file).with_content(/--log-opt max-size=1m/) }
+        it { should contain_file(service_config_file).with_content(/--log-opt max-file=3/) }
+      end
+
+      context 'without log_driver no log_opt' do
+        let(:params) { { 'log_opt' => [ 'max-size=1m' ] } }
+        it { should_not contain_file(service_config_file).with_content(/--log-opt max-size=1m/) }
+      end
+
       context 'with specific selinux_enabled parameter' do
         let(:params) { { 'selinux_enabled' => 'true' } }
         it { should contain_file(service_config_file).with_content(/--selinux-enabled=true/) }


### PR DESCRIPTION
We wish to be able to set the log-opt on service level instead of needing to set it for each different run setup