### PR TITLE
add service_manage parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,11 @@
 #   Whether you want to docker daemon to start up at boot
 #   Defaults to true
 #
+# [*service_manage*]
+#   Specify whether the service should be managed.
+#   Valid values are 'true', 'false'.
+#   Defaults to 'true'.
+#
 # [*root_dir*]
 #   Custom root directory for containers
 #   Defaults to undefined
@@ -253,6 +258,7 @@ class docker(
   $package_key_source                = $docker::params::package_key_source,
   $service_state                     = $docker::params::service_state,
   $service_enable                    = $docker::params::service_enable,
+  $service_manage                    = $docker::params::service_manage,
   $root_dir                          = $docker::params::root_dir,
   $tmp_dir                           = $docker::params::tmp_dir,
   $manage_kernel                     = $docker::params::manage_kernel,
@@ -310,6 +316,7 @@ class docker(
   validate_re($::osfamily, '^(Debian|RedHat|Archlinux)$', 'This module only works on Debian and Red Hat based systems.')
   validate_bool($manage_kernel)
   validate_bool($manage_package)
+  validate_bool($service_manage)
   validate_array($docker_users)
   validate_array($log_opt)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class docker::params {
   $socket_group                      = undef
   $service_state                     = running
   $service_enable                    = true
+  $service_manage                    = true
   $root_dir                          = undef
   $tmp_dir                           = '/tmp/'
   $dns                               = undef

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -339,6 +339,11 @@ describe 'docker', :type => :class do
         it { should contain_service('docker').with_enable('true') }
       end
 
+      context 'with service_manage set to false' do
+        let(:params) { {'service_manage' => false} }
+        it { subject.should_not contain_service('docker') }
+      end
+
       context 'with specific log_level' do
         let(:params) { { 'log_level' => 'debug' } }
         it { should contain_file(service_config_file).with_content(/-l debug/) }


### PR DESCRIPTION
### service_manage

Specify whether the service should be managed. Valid values are 'true', 'false'. Defaults to 'true'.

```yaml
docker::service_manage: false
```
Since docker doesn't provide a reload option. I would use this option for production environments. Otherwise all docker containers running on the host will be shutdown, when the docker daemon gets reloaded.