### PR TITLE
Bug/systemd reload order

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,12 +58,14 @@ class docker::params {
           $package_release = "ubuntu-${::lsbdistcodename}"
           if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
             include docker::systemd_reload
+            include docker::systemd_reload_before_service
           }
         }
         default: {
           $package_release = "debian-${::lsbdistcodename}"
           if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
             include docker::systemd_reload
+            include docker::systemd_reload_before_service
           }
         }
       }
@@ -128,6 +130,7 @@ class docker::params {
           $docker_group = 'dockerroot'
         }
         include docker::systemd_reload
+        include docker::systemd_reload_before_service
       }
 
       # repo_opt to specify install_options for docker package
@@ -157,6 +160,7 @@ class docker::params {
     }
     'Archlinux' : {
       include docker::systemd_reload
+      include docker::systemd_reload_before_service
       $manage_epel = false
       $docker_group = $docker_group_default
       $package_key_source = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -95,7 +95,8 @@ class docker::service (
         file { '/etc/systemd/system/docker.service.d/service-overrides.conf':
           ensure  => present,
           content => template('docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'),
-          notify  => Exec['docker-systemd-reload'];
+          notify  => Exec['docker-systemd-reload-before-service'],
+          before  => Service['docker'],
         }
         file { '/etc/default/docker-storage':
           ensure  => present,
@@ -142,7 +143,8 @@ class docker::service (
         file { '/etc/systemd/system/docker.service.d/service-overrides.conf':
           ensure  => present,
           content => template('docker/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb'),
-          notify  => Exec['docker-systemd-reload'];
+          notify  => Exec['docker-systemd-reload-before-service'],
+          before  => Service['docker'],
         }
       }
 
@@ -173,7 +175,8 @@ class docker::service (
       file { '/etc/systemd/system/docker.service.d/service-overrides.conf':
         ensure  => present,
         content => template('docker/etc/systemd/system/docker.service.d/service-overrides-archlinux.conf.erb'),
-        notify  => Exec['docker-systemd-reload'];
+        notify  => Exec['docker-systemd-reload-before-service'],
+        before  => Service['docker'],
       }
 
       file { '/etc/conf.d/docker':

--- a/manifests/systemd_reload_before_service.pp
+++ b/manifests/systemd_reload_before_service.pp
@@ -6,9 +6,9 @@
 # the 'docker-systemd-reload' exec cannot be used to protect the service resource as it will introduce a dependency cycle through docker::run of containers.
 class docker::systemd_reload_before_service {
   exec { 'docker-systemd-reload-before-service':
-    path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
-    command     => 'systemctl daemon-reload',
-    before      => Service['docker'],
-    unless      => 'systemctl status docker'
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+    command => 'systemctl daemon-reload',
+    before  => Service['docker'],
+    unless  => 'systemctl status docker'
   }
 }

--- a/manifests/systemd_reload_before_service.pp
+++ b/manifests/systemd_reload_before_service.pp
@@ -1,0 +1,14 @@
+# == Class: docker::systemd_reload_before_service
+#
+# For systems that have systemd
+#
+# Additional non refreshonly systemd reload, which is required for incompatible changes to the docker service definition.
+# the 'docker-systemd-reload' exec cannot be used to protect the service resource as it will introduce a dependency cycle through docker::run of containers.
+class docker::systemd_reload_before_service {
+  exec { 'docker-systemd-reload-before-service':
+    path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+    command     => 'systemctl daemon-reload',
+    before      => Service['docker'],
+    unless      => 'systemctl status docker'
+  }
+}


### PR DESCRIPTION
we ran into a very annoying issue where docker wouldn't start because of the way the systemd service definition was managed.
initially the service was started without '/etc/systemd/system/docker.service.d/service-overrides.conf'. so would start with a default loopback dm setup in /var/lib/docker/devicemapper.
we had configured a non loopback dm storage, which caused the docker daemon to error on the systemd-reload and restart after the service-overrides was written. lvm setup got messed up, and system state fairly unusable.

this pr addresses the issue we faced by seperating the systemd-reload logic for initial service definition from the reload logic used by docker::run, and introducing stricter dependencies between the puppet resources. we were no longer able to reproduce the issue with these changes.

also note that the issue was only reproducible with a manifest that combined the docker service and some container startups with docker::run. with a simple "include 'docker'", the docker config was being setup correctly.