### PR TITLE
add service provider systemd for debian jessie or ubuntu

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -190,6 +190,9 @@ class docker::service (
 
   if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') < 0 {
     $provider = 'upstart'
+  }
+  elsif ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+    $provider = 'systemd'
   } else {
     $provider = undef
   }


### PR DESCRIPTION
#### docker daemon was running twice

the problem occurred, because initd and systemd were starting up the docker daemon at boot time

```bash
root       855  0.6  0.1 304380 32396 ?        Ssl  10:01   0:00 /usr/bin/docker daemon -H unix:///var/run/docker.sock --ip-forward=true --iptables=true --ip-masq=true
root      2052  0.6  0.1 304380 32212 ?        Sl   10:01   0:00 /usr/bin/docker daemon -p /var/run/docker.pid
```

I've add systemd as default provider for jessie systems. 
This could be parameterized.