### PR TITLE
Prevent reserved keyword interpretation in embedded string

### DIFF
--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -39,7 +39,7 @@ define docker::exec(
   $unless_command = $unless ? {
       undef              => undef,
       ''                 => undef,
-      default            => "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${unless}",
+      default            => "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${$unless}",
   }
 
   exec { $exec:


### PR DESCRIPTION
Per Puppet doc :
(https://docs.puppetlabs.com/puppet/latest/reference/lang_data_string.html)

    ${myvariable} — A dollar sign followed by a variable name in curly
    braces will be replaced with that variable’s value. This also works
    with qualified variable names like ${myclass::myvariable}.
    With this syntax, you can also follow a variable name with any
    combination of chained function calls and/or hash access / array
    access / substring access expressions.

And "unless" is indeed a reserved keyword :
https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html

So using ${unless} as a string trips up the parser badly (at least for my 3.4
using "future" parser) :

    puppet parser --parser=future validate docker/manifests/exec.pp
    Error: Could not parse for environment production: Syntax error at '' at docker/manifests/exec.pp:42:105

We must use the ${$keyword} syntax to prevent the issue.