### PR TITLE
ensure idempotence

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -116,7 +116,10 @@ define docker::run(
   validate_bool($use_name)
 
   if $use_name {
-    notify { 'The use_name parameter is no-longer required and will be removed in a future release': withpath => true }
+    notify { "docker use_name warning: ${title}":
+      message  => 'The use_name parameter is no-longer required and will be removed in a future release',
+      withpath => true,
+    }
   }
 
   validate_hash($extra_systemd_parameters)


### PR DESCRIPTION
This ensure idempotence when multiple `docker::run` resources are declared