### PR TITLE
Add before_start parameter for docker::run

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -83,6 +83,7 @@ define docker::run(
   $socket_connect = [],
   $hostentries = [],
   $restart = undef,
+  $before_start = false,
   $before_stop = false,
 ) {
   include docker::params

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -325,6 +325,16 @@ require 'spec_helper'
       it { should_not contain_file(initscript).with_content(/docker pull base/) }
     end
 
+    context 'when `before_start` is set' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'before_start' => "echo before_start" } }
+      it { should contain_file(initscript).with_content(/before_start/) }
+    end
+
+    context 'when `before_start` is not set' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'before_start' => false } }
+      it { should_not contain_file(initscript).with_content(/before_start/) }
+    end
+
     context 'when `before_stop` is set' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'before_stop' => "echo before_stop" } }
       it { should contain_file(initscript).with_content(/before_stop/) }

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -74,6 +74,9 @@ start() {
     fi
 
     printf "Starting $prog:\t"
+    <% if @before_start -%>
+        <%= @before_start %>
+    <% end -%>
     $docker rm -v <%= @sanitised_title %> >/dev/null 2>&1
     <% if @pull_on_start -%>
         $docker pull <%= @image %>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -23,6 +23,8 @@ StartLimitInterval=20
 StartLimitBurst=5
 TimeoutStartSec=0
 Environment="HOME=/root"
+<%- if @before_start %>ExecStartPre=-<%= @before_start %>
+<% end -%>
 ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 ExecStartPre=-/usr/bin/<%= @docker_command %> rm -v <%= @sanitised_title %>
 <% @extra_systemd_parameters.each do |key, value| -%><%= key %>=<%= value %>


### PR DESCRIPTION
This adds a complement to before_stop.  Any command passed in as the
before_start parameter will be run before beginning any start related
cleanup or commands.
