### PR TITLE
Define service_hasstatus service_hasrestart parameters

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,8 @@ class docker::params {
             $service_provider        = 'systemd'
             $storage_config          = '/etc/default/docker-storage'
             $service_config_template = 'docker/etc/sysconfig/docker.systemd.erb'
+            $service_hasstatus       = true
+            $service_hasrestart      = true
             include docker::systemd_reload
           } else {
             $service_config_template = 'docker/etc/default/docker.erb'
@@ -78,6 +80,8 @@ class docker::params {
             $storage_config             = '/etc/default/docker-storage'
             $service_config_template    = 'docker/etc/sysconfig/docker.systemd.erb'
             $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
+            $service_hasstatus       = true
+            $service_hasrestart      = true
             include docker::systemd_reload
           } else {
             $service_config_template = 'docker/etc/default/docker.erb'
@@ -108,6 +112,8 @@ class docker::params {
     'RedHat' : {
       $service_config = '/etc/sysconfig/docker'
       $storage_config = '/etc/sysconfig/docker-storage'
+      $service_hasstatus  = true
+      $service_hasrestart = true
 
       if ($::operatingsystem == 'Fedora') or (versioncmp($::operatingsystemrelease, '7.0') >= 0) {
         $service_provider           = 'systemd'
@@ -215,6 +221,8 @@ class docker::params {
       $package_repos = undef
       $package_release = undef
       $use_upstream_package_source = true
+      $service_hasstatus  = undef
+      $service_hasrestart = undef
       $package_name = $package_name_default
       $service_name = $service_name_default
       $docker_command = $docker_command_default

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -636,7 +636,7 @@ describe 'docker', :type => :class do
     service_config_file = '/etc/sysconfig/docker'
     it { should contain_file(service_config_file).with_content(/^http_proxy='http:\/\/127.0.0.1:3128'/) }
     it { should contain_file(service_config_file).with_content(/^  https_proxy='http:\/\/127.0.0.1:3128'/) }
-
+    it { should contain_service('docker').with_provider('systemd').with_hasstatus(true).with_hasrestart(true) }
   end
 
   context 'specific to Oracle Linux 7 or above' do
@@ -707,7 +707,7 @@ describe 'docker', :type => :class do
         :kernelrelease          => '3.8.0-29-generic'
       } }
 
-      it { should contain_service('docker').with_provider('systemd') }
+      it { should contain_service('docker').with_provider('systemd').with_hasstatus(true).with_hasrestart(true) }
     end
 
     context 'Debian >= 8' do
@@ -720,7 +720,7 @@ describe 'docker', :type => :class do
         :operatingsystemmajrelease => '8',
       } }
 
-      it { should contain_service('docker').with_provider('systemd') }
+      it { should contain_service('docker').with_provider('systemd').with_hasstatus(true).with_hasrestart(true) }
     end
   end
 


### PR DESCRIPTION
These two parameters weren't set in different OS family/system. systemd enabled OS have restart and status capability.