### PR TITLE
Update run manifest to use service_prefix and docker_command params throughout

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -179,11 +179,11 @@ define docker::run(
 
   if $restart {
 
-    $cidfile = "/var/run/docker-${sanitised_title}.cid"
+    $cidfile = "/var/run/${service_prefix}${sanitised_title}.cid"
 
     exec { "run ${title} with docker":
       command     => "${docker_command} run -d ${docker_run_flags} --name ${sanitised_title} --cidfile=${cidfile} --restart=\"${restart}\" ${image} ${command}",
-      unless      => "docker ps --no-trunc -a | grep `cat ${cidfile}`",
+      unless      => "${docker_command} ps --no-trunc -a | grep `cat ${cidfile}`",
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
       timeout     => 0
@@ -243,9 +243,9 @@ define docker::run(
 
         exec {
           "remove container ${service_prefix}${sanitised_title}":
-            command     => "docker rm -v ${sanitised_title}",
+            command     => "${docker_command} rm -v ${sanitised_title}",
             refreshonly => true,
-            onlyif      => "docker ps --no-trunc -a --format='table {{.Names}}' | grep '^${sanitised_title}$'",
+            onlyif      => "${docker_command} ps --no-trunc -a --format='table {{.Names}}' | grep '^${sanitised_title}$'",
             path        => ['/bin', '/usr/bin'],
             environment => 'HOME=/root',
             timeout     => 0
@@ -280,7 +280,7 @@ define docker::run(
               onlyif  => "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid && /usr/bin/test -f /etc/init.d/${service_prefix}${sanitised_title}",
               require => [],
             } ->
-            file { "/var/run/docker-${sanitised_title}.cid":
+            file { "/var/run/${service_prefix}${sanitised_title}.cid":
               ensure => absent,
             } ->
             File[$initscript]


### PR DESCRIPTION
docker_command and service_prefix are missed in a couple locations, this updates the run manifest to use them through out