### PR TITLE
Change update_docker_image from File to ensure_resource

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -35,6 +35,17 @@ define docker::image(
   validate_re($image, '^[\S]*$')
   validate_bool($force)
 
+  # Wrapper used to ensure images are up to date
+  ensure_resource('file', '/usr/local/bin/update_docker_image.sh',
+    {
+      ensure  => $docker::params::ensure,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0555',
+      content => template('docker/update_docker_image.sh.erb'),
+    }
+  )
+
   if ($docker_file) and ($docker_dir) {
     fail 'docker::image must not have both $docker_file and $docker_dir set'
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -102,13 +102,4 @@ class docker::install {
       }))
     }
   }
-
-  # Wrapper used by docker::image to ensure images are up to date
-  file { '/usr/local/bin/update_docker_image.sh':
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0555',
-    content => template('docker/update_docker_image.sh.erb'),
-  }
-
 }

--- a/spec/defines/image_spec.rb
+++ b/spec/defines/image_spec.rb
@@ -20,6 +20,7 @@ describe 'docker::image', :type => :define do
 
   context 'with ensure => present' do
     let(:params) { { 'ensure' => 'present' } }
+    it { should contain_file('/usr/local/bin/update_docker_image.sh') }
     it { should contain_exec('/usr/local/bin/update_docker_image.sh base') }
   end
 


### PR DESCRIPTION
Changes how update_docker_image.sh is created and adds an ensure so it can
properly be removed if ensure => absent is set. Also adds test case to cover the
missed resource in the coverage report.

Introduced in pr #237