### PR TITLE
Amazon linux is still based on centos 6.x, yet the version is like 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,7 +147,7 @@ class docker::params {
       $package_release = undef
       $service_name = $service_name_default
       $docker_command = $docker_command_default
-      if versioncmp($::operatingsystemrelease, '7.0') < 0 {
+      if (versioncmp($::operatingsystemrelease, '7.0') < 0) or ($::operatingsystem == 'Amazon') {
         $detach_service_in_init = true
         if $::operatingsystem == 'OracleLinux' {
           $docker_group = 'dockerroot'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,7 +115,7 @@ class docker::params {
       $service_hasstatus  = true
       $service_hasrestart = true
 
-      if ($::operatingsystem == 'Fedora') or (versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+      if ($::operatingsystem == 'Fedora') or (versioncmp($::operatingsystemrelease, '7.0') >= 0) and $::operatingsystem != 'Amazon' {
         $service_provider           = 'systemd'
         $service_config_template    = 'docker/etc/sysconfig/docker.systemd.erb'
         $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb'

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -739,6 +739,16 @@ describe 'docker', :type => :class do
     end
   end
 
+  context 'specific to Amazon Linux (based on centos6) distros' do
+    let(:facts) { {
+      :osfamily => 'RedHat',
+      :operatingsystem => 'Amazon',
+      :operatingsystemrelease => '2015.09',
+      :operatingsystemmajrelease => '2015',
+    } }
+    it {should contain_service('docker').without_provider }
+  end
+
   context 'with an invalid distro name' do
     let(:facts) { {:osfamily => 'Gentoo'} }
     it do

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-['Debian', 'RedHat', 'Archlinux'].each do |osfamily|
+['Debian', 'RedHat', 'Archlinux', 'Amazon'].each do |osfamily|
 
   describe 'docker::run', :type => :define do
     let(:title) { 'sample' }
@@ -24,12 +24,22 @@ require 'spec_helper'
       initscript = '/etc/systemd/system/docker-sample.service'
       command = 'docker'
       systemd = true
-    else
+    elsif osfamily == 'RedHat'
       let(:facts) { {
         :osfamily => 'RedHat',
         :operatingsystem => 'RedHat',
         :operatingsystemrelease => '6.6',
         :operatingsystemmajrelease => '6',
+      } }
+      initscript = '/etc/init.d/docker-sample'
+      command = 'docker'
+      systemd = false
+    else
+      let(:facts) { {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'Amazon',
+        :operatingsystemrelease => '2015.09',
+        :operatingsystemmajrelease => '2015',
       } }
       initscript = '/etc/init.d/docker-sample'
       command = 'docker'


### PR DESCRIPTION
'2015.xx'. It still requires detach in init as far as I can tell. This seems to have regressed somewhere

I didn't see a good place to insert a test since it'd only be able to run in AWS, but would happy to take a pointer and run with it.