### PR TITLE
Add MIN_DATA_SIZE to docker-storage-setup template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -220,6 +220,9 @@
 # [*storage_data_size*]
 #   The desired size for the docker data LV
 #
+# [*storage_min_data_size*]
+#   The minimum size of data volume otherwise pool creation fails
+#
 # [*storage_chunk_size*]
 #   Controls the chunk size/block size of thin pool.
 #
@@ -291,6 +294,7 @@ class docker(
   $storage_vg                        = $docker::params::storage_vg,
   $storage_root_size                 = $docker::params::storage_root_size,
   $storage_data_size                 = $docker::params::storage_data_size,
+  $storage_min_data_size             = $docker::params::storage_min_data_size,
   $storage_chunk_size                = $docker::params::storage_chunk_size,
   $storage_growpart                  = $docker::params::storage_growpart,
   $storage_auto_extend_pool          = $docker::params::storage_auto_extend_pool,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,6 +46,7 @@ class docker::params {
   $storage_vg                        = undef
   $storage_root_size                 = undef
   $storage_data_size                 = undef
+  $storage_min_data_size             = undef
   $storage_chunk_size                = undef
   $storage_growpart                  = undef
   $storage_auto_extend_pool          = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -61,6 +61,7 @@ class docker::service (
   $storage_vg                        = $docker::storage_vg,
   $storage_root_size                 = $docker::storage_root_size,
   $storage_data_size                 = $docker::storage_data_size,
+  $storage_min_data_size             = $docker::storage_min_data_size,
   $storage_chunk_size                = $docker::storage_chunk_size,
   $storage_growpart                  = $docker::storage_growpart,
   $storage_auto_extend_pool          = $docker::storage_auto_extend_pool,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -591,6 +591,11 @@ describe 'docker', :type => :class do
         it { should contain_file(storage_setup_file).with_content(/^DATA_SIZE=10G/) }
       end
 
+      context 'with storage min data size' do
+        let(:params) { { 'storage_min_data_size' => '2G' }}
+        it { should contain_file(storage_setup_file).with_content(/^MIN_DATA_SIZE=2G/) }
+      end
+
       context 'with storage chunk size' do
         let(:params) { { 'storage_chunk_size' => '10G' }}
         it { should contain_file(storage_setup_file).with_content(/^CHUNK_SIZE=10G/) }

--- a/templates/etc/sysconfig/docker-storage-setup.erb
+++ b/templates/etc/sysconfig/docker-storage-setup.erb
@@ -16,6 +16,8 @@
 <% end -%>
 <% if @storage_data_size %>DATA_SIZE=<%= @storage_data_size %>
 <% end -%>
+<% if @storage_min_data_size %>MIN_DATA_SIZE=<%= @storage_min_data_size %>
+<% end -%>
 <% if @storage_chunk_size %>CHUNK_SIZE=<%= @storage_chunk_size %>
 <% end -%>
 <% if @storage_growpart %>GROWPART=<%= @storage_growpart %>


### PR DESCRIPTION
Add a storage template configuration option MIN_DATA_SIZE to allows users to specify minimum size of data pool volumes. This is needed to prevent small pools from hanging on the first image pull.