### PR TITLE
Add dm_option for deferred device deletion

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,9 @@
 # [*dm_use_deferred_removal*]
 #   Enables use of deferred device removal if libdm and the kernel driver support the mechanism.
 #
+# [*dm_use_deferred_deletion*]
+#    Enables use of deferred device deletion if libdm and the kernel driver support the mechanism.
+#
 # [*dm_blkdiscard*]
 #   Enables or disables the use of blkdiscard when removing devicemapper devices.
 #   Defaults to false
@@ -278,6 +281,7 @@ class docker(
   $dm_metadatadev                    = $docker::params::dm_metadatadev,
   $dm_thinpooldev                    = $docker::params::dm_thinpooldev,
   $dm_use_deferred_removal           = $docker::params::dm_use_deferred_removal,
+  $dm_use_deferred_deletion          = $docker::params::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
   $execdriver                        = $docker::params::execdriver,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class docker::params {
   $dm_metadatadev                    = undef
   $dm_thinpooldev                    = undef
   $dm_use_deferred_removal           = undef
+  $dm_use_deferred_deletion          = undef
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
   $manage_package                    = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -55,6 +55,7 @@ class docker::service (
   $nowarn_kernel                     = $docker::nowarn_kernel,
   $dm_thinpooldev                    = $docker::dm_thinpooldev,
   $dm_use_deferred_removal           = $docker::dm_use_deferred_removal,
+  $dm_use_deferred_deletion          = $docker::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::dm_override_udev_sync_check,
   $storage_devs                      = $docker::storage_devs,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -249,6 +249,15 @@ describe 'docker', :type => :class do
         it { should contain_file(storage_config_file).with_content(/--storage-opt dm\.use_deferred_removal=true/) }
       end
 
+      context 'with use deferred deletion param' do
+        let(:params) {
+          { 'storage_driver' => 'devicemapper',
+            'dm_use_deferred_deletion' => 'true'
+          }
+        }
+        it { should contain_file(storage_config_file).with_content(/--storage-opt dm\.use_deferred_deletion=true/) }
+      end
+
       context 'with block discard param' do
         let(:params) {
           { 'storage_driver' => 'devicemapper',

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -30,6 +30,7 @@ other_args="<% -%>
 <% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
 <% end -%>
 <% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -45,6 +45,7 @@ DOCKER_OPTS="\
 <% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
 <% end -%>
 <% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>

--- a/templates/etc/sysconfig/docker-storage.erb
+++ b/templates/etc/sysconfig/docker-storage.erb
@@ -30,6 +30,7 @@ DOCKER_STORAGE_OPTIONS="<% -%>
 <% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
 <% end -%>
 <% if @dm_use_deferred_removal %> --storage-opt dm.use_deferred_removal=<%= @dm_use_deferred_removal %><% end -%>
+<% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>


### PR DESCRIPTION
Adds the missing option for deferred device deletion to storage configs

  --storage-opt dm.use_deferred_deletion=true

Introduced in Docker pr 16381