### PR TITLE
Chained ordering leaves out Docker::Registry

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -368,7 +368,5 @@ class docker(
 
   # Only bother trying extra docker stuff after docker has been installed,
   # and is running.
-  Class['docker'] -> Docker::Registry <||> -> Docker::Run <||>
-  Class['docker'] -> Docker::Image <||>
-
+  Class['docker'] -> Docker::Registry <||> -> Docker::Image <||> -> Docker::Run <||>
 }


### PR DESCRIPTION
Updates ordering to ensure Registries are created before Image or
Run resources could potentially try and use them.

Closes #408