### PR TITLE
prevent docker service startup with wrong configuration

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,6 +67,7 @@ class docker::params {
             $service_hasstatus       = true
             $service_hasrestart      = true
             include docker::systemd_reload
+            include docker::systemd_reload_before_service
           } else {
             $service_config_template = 'docker/etc/default/docker.erb'
             $service_provider        = 'upstart'
@@ -84,6 +85,7 @@ class docker::params {
             $service_hasstatus       = true
             $service_hasrestart      = true
             include docker::systemd_reload
+            include docker::systemd_reload_before_service
           } else {
             $service_config_template = 'docker/etc/default/docker.erb'
           }
@@ -163,6 +165,7 @@ class docker::params {
           $docker_group = 'dockerroot'
         }
         include docker::systemd_reload
+        include docker::systemd_reload_before_service
       }
 
       # repo_opt to specify install_options for docker package
@@ -192,6 +195,8 @@ class docker::params {
     }
     'Archlinux' : {
       include docker::systemd_reload
+      include docker::systemd_reload_before_service
+
       $manage_epel = false
       $docker_group = $docker_group_default
       $package_key_source = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -114,7 +114,8 @@ class docker::service (
         file { '/etc/systemd/system/docker.service.d/service-overrides.conf':
           ensure  => present,
           content => template($service_overrides_template),
-          notify  => Exec['docker-systemd-reload']
+          notify  => Exec['docker-systemd-reload-before-service'],
+          before  => Service['docker'],
         }
       }
     }

--- a/manifests/systemd_reload_before_service.pp
+++ b/manifests/systemd_reload_before_service.pp
@@ -1,0 +1,19 @@
+# == Class: docker::systemd_reload_before_service
+#
+# For systems that have systemd
+#
+# Additional non refreshonly systemd reload, which is required for incompatible changes to the docker service definition.
+# the 'docker-systemd-reload' exec cannot be used to protect the service resource as it will introduce a dependency cycle through docker::run of containers.
+class docker::systemd_reload_before_service {
+  include docker::params
+  $service_name = $docker::params::service_name
+
+  validate_string($service_name)
+
+  exec { 'docker-systemd-reload-before-service':
+    path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+    command => 'systemctl daemon-reload',
+    before  => Service[$service_name],
+    unless  => 'systemctl status docker'
+  }
+}


### PR DESCRIPTION
Intitial patch submitted by @wscheele in #398

This patch extends the work initially done by rebasing against current master
and fixing the broken test case dependency cycles.

Closes #398
Closes #407