### PR TITLE
Add description to yum repo

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -36,6 +36,7 @@ class docker::repos {
       if $docker::manage_package {
         if ($docker::use_upstream_package_source) {
           yumrepo { 'docker':
+            descr    => 'Docker',
             baseurl  => $docker::package_source_location,
             gpgkey   => $docker::package_key_source,
             gpgcheck => true,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -551,7 +551,7 @@ describe 'docker', :type => :class do
     } }
 
     it { should contain_package('docker').with_name('docker-engine') }
-    it { should contain_yumrepo('docker') }
+    it { should contain_yumrepo('docker').with_descr('Docker') }
     it { should_not contain_class('epel') }
   end
 


### PR DESCRIPTION
Adds a description to yumrepo to remove warnings of "Repository 'docker' is missing name in configuration, using id".