### PR TITLE
Use current docker daemon command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -204,6 +204,10 @@
 #   Specify a custom docker command name
 #   Default is set on a per system basis in docker::params
 #
+# [*daemon_flag*]
+#  Specify a flag for running docker as daemon
+#  Default is set on a per system basis in docker::params
+#
 # [*docker_users*]
 #   Specify an array of users to add to the docker group
 #   Default is empty
@@ -291,6 +295,7 @@ class docker(
   $package_name                      = $docker::params::package_name,
   $service_name                      = $docker::params::service_name,
   $docker_command                    = $docker::params::docker_command,
+  $daemon_flag                       = $docker::params::daemon_flag,
   $docker_users                      = [],
   $repo_opt                          = $docker::params::repo_opt,
   $nowarn_kernel                     = $docker::params::nowarn_kernel,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class docker::params {
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
+  $daemon_flag_default               = 'daemon'
   $storage_devs                      = undef
   $storage_vg                        = undef
   $storage_root_size                 = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,6 +24,7 @@
 class docker::service (
   $docker_command                    = $docker::docker_command,
   $service_name                      = $docker::service_name,
+  $daemon_flag                       = $docker::daemon_flag,
   $tcp_bind                          = $docker::tcp_bind,
   $socket_bind                       = $docker::socket_bind,
   $log_level                         = $docker::log_level,

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,5 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> -d -H fd:// $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_command %> daemon -H fd:// $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -3,7 +3,7 @@ EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> -d -H fd:// $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_command %> daemon -H fd:// $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
`docker -d` has been deprecated
the command is now `docker daemon`
https://github.com/docker/docker/blob/master/CHANGELOG.md#180-2015-08-11