### PR TITLE
fix docker network type and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,11 +316,11 @@ like:
 
 ```puppet
 docker_network { 'my-net':
-  ensure  => present,
-  driver  => 'overlay',
-  subnet  => '192.168.1.0/24',
-  gateway => '192.168.1.1',
-  iprange => '192.168.1.4/32',
+  ensure   => present,
+  driver   => 'overlay',
+  subnet   => '192.168.1.0/24',
+  gateway  => '192.168.1.1',
+  ip_range => '192.168.1.4/32',
 }
 ```
 

--- a/lib/puppet/provider/docker_network/ruby.rb
+++ b/lib/puppet/provider/docker_network/ruby.rb
@@ -12,13 +12,13 @@ Puppet::Type.type(:docker_network).provide(:ruby) do
     }
 
     [
-      ['--driver %s',       :driver],
-      ['--subnet %s',       :subnet],
-      ['--gateway %s',      :gateway],
-      ['--ip-range %s',     :ip_range],
-      ['--ipam-driver %s',  :ipam_driver],
-      ['--aux-address %s',  :aux_address],
-      ['--opt %s',          :options],
+      ['--driver=%s',       :driver],
+      ['--subnet=%s',       :subnet],
+      ['--gateway=%s',      :gateway],
+      ['--ip-range=%s',     :ip_range],
+      ['--ipam-driver=%s',  :ipam_driver],
+      ['--aux-address=%s',  :aux_address],
+      ['--opt=%s',          :options],
     ].each do |(format, key)|
       values    = resource[key]
       new_flags = multi_flags.call(values, format)


### PR DESCRIPTION
The readme has the wrong attribute name iprange should be ip_range and I got this error when running on centos7:

Execution of '/usr/bin/docker network create --driver overlay --subnet
192.168.1.0/24 --gateway 192.168.1.1 --ip-range 192.168.1.4/24 adnets'
returned 1: flag provided but not defined: --driver overlay
See '/usr/bin/docker network create --help'.
flag provided but not defined: --driver overlay

So I put = between the args and the value. 