### PR TITLE
Fix services overrides template daemon command

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,7 @@ class docker::params {
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
-  $daemon_subcommand_default         = 'daemon'
+  $daemon_subcommand                 = 'daemon'
   $storage_devs                      = undef
   $storage_vg                        = undef
   $storage_root_size                 = undef


### PR DESCRIPTION
params daemon_command_default is never set to the global daemon_command which
causes the service overrides templates to have a blank value in the erb
ExecStart line.