### PR TITLE
Fix dependency cycle with docker::run

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -326,8 +326,14 @@ define docker::run(
         }
       }
       if $uses_systemd {
-        File[$initscript] ~> Exec['docker-systemd-reload']
-        Exec['docker-systemd-reload'] -> Service<| title == "${service_prefix}${sanitised_title}" |>
+        exec { "docker-${sanitised_title}-systemd-reload":
+          path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+          command     => 'systemctl daemon-reload',
+          refreshonly => true,
+          require     => File[$initscript],
+          subscribe   => File[$initscript],
+        }
+        Exec["docker-${sanitised_title}-systemd-reload"] -> Service<| title == "${service_prefix}${sanitised_title}" |>
       }
 
       if $restart_service {


### PR DESCRIPTION
The docker::run command when using systemd notifies the exec for
reload, but then the service requires this exec. If you have multiple
runs, this creates a dependency cycle. I added a new exec based on the
sanitised title of the run so sure it wastes cycles reloading multiple
times, but it doesn't fail.

This addresses #401 