### PR TITLE
add docker stop with stop timeout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ with:
     bundle exec rake beaker
 
 This will run the tests on an Ubuntu 12.04 virtual machine. You can also
-run the integration tests against Centos 6.5 with:
+run the integration tests against Centos 7.0 with:
 
     BEAKER_set=centos-70-x64 bundle exec rake beaker
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -48,6 +48,10 @@
 # command. Useful for adding additional new or experimental options that the
 # module does not yet support.
 #
+# [*stop_timeout*]
+# (optional) - string
+# Add optional parameter -t <timeout> to docker stop
+#
 define docker::run(
   $image,
   $ensure = 'present',
@@ -91,6 +95,7 @@ define docker::run(
   $restart = undef,
   $before_start = false,
   $before_stop = false,
+  $stop_timeout = false,
   $remove_container_on_start = true,
   $remove_container_on_stop = true,
   $remove_volume_on_start = false,
@@ -136,7 +141,13 @@ define docker::run(
   validate_bool($remove_volume_on_stop)
   validate_bool($use_name)
 
+<<<<<<< HEAD
   validate_integer($stop_wait_time)
+=======
+  if $stop_timeout != false {
+    validate_re($stop_timeout, '^[0-9]+$')
+  }
+>>>>>>> fe4c6e7... Added docker stop timeout possibility
 
   if ($remove_volume_on_start and !$remove_container_on_start) {
     fail("In order to remove the volume on start for ${title} you need to also remove the container")

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -672,6 +672,20 @@ require 'spec_helper'
       it { should contain_exec("remove container docker-sample").with_command('docker rm -v sample') }
     end
 
+    context 'with stop_timeout set to some value' do
+      let(:title) { 'my-container' }
+      let(:params) { {'image' => 'base', 'stop_timeout' => '1234567890',} }
+
+      if initscript =~ /^\/etc\/init.d\/docker-sample$/
+        new_initscript = '/etc/init.d/docker-my-container'
+        it { should contain_file(new_initscript).with_content(/\$docker stop -t 1234567890 my-container$/) }
+
+      elsif initscript =~ /^\/etc\/systemd\/system\/docker-sample\.service$/
+        new_initscript = '/etc/systemd/system/docker-my-container.service'
+        it { should contain_file(new_initscript).with_content(/^ExecStop=-\/usr\/bin\/docker stop -t 1234567890 my-container$/) }
+      end
+    end
+
   end
   end
 

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -113,7 +113,11 @@ stop() {
     <% if @before_stop -%>
         <%= @before_stop %>
     <% end -%>
+<<<<<<< HEAD
     $docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
+=======
+    $docker stop <% if @stop_timeout != false %>-t <%= @stop_timeout %> <% end %><%= @sanitised_title %>
+>>>>>>> fe4c6e7... Added docker stop timeout possibility
     <% if @remove_container_on_stop -%>
         $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
     <% end -%>

--- a/templates/etc/init.d/docker-run.gentoo.erb
+++ b/templates/etc/init.d/docker-run.gentoo.erb
@@ -76,7 +76,11 @@ stop() {
     <% if @before_stop -%>
         <%= @before_stop %>
     <% end -%>
+<<<<<<< HEAD
     $docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
+=======
+    $docker stop <% if @stop_timeout != false %>-t <%= @stop_timeout %> <% end %><%= @sanitised_title %>
+>>>>>>> fe4c6e7... Added docker stop timeout possibility
     <% if @remove_container_on_stop -%>
     $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
     <% end -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -48,7 +48,11 @@ ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
 <% end -%>
 <%- if @before_stop %>ExecStop=-<%= @before_stop %>
 <% end -%>
+<<<<<<< HEAD
 ExecStop=-/usr/bin/<%= @docker_command %> stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
+=======
+ExecStop=-/usr/bin/<%= @docker_command %> stop <% if @stop_timeout != false %>-t <%= @stop_timeout %> <% end %><%= @sanitised_title %>
+>>>>>>> fe4c6e7... Added docker stop timeout possibility
 <%- if @remove_container_on_stop %>ExecStop=-/usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
 <% end -%>
 


### PR DESCRIPTION
I've made two changes in module:
- add support of timeout in docker stop: docker stop -t <timeout> (optional)
https://docs.docker.com/engine/reference/commandline/stop/

- one correction of typo in CONTRIBUTING.md

I added one test which checks if docker stop -t <timeout> is added. More detailed tests could check validation of parameter and it initial state. If you want them, let me know :)

~~I found one problem - there is difference between init script and systemd service in stop methods: systemd makes docker kill, init script makes docker stop. I think it could be aligned to one common method.~~