### PR TITLE
Stop container in ExecStop instead of kill

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -39,7 +39,7 @@ ExecStart=/usr/bin/<%= @docker_command %> run \
         <% if @command %> <%= @command %><% end %>
 <%- if @before_stop %>ExecStop=-<%= @before_stop %>
 <% end -%>
-ExecStop=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
+ExecStop=-/usr/bin/<%= @docker_command %> stop <%= @sanitised_title %>
 <%- if @remove_container_on_stop %>ExecStop=-/usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
 <% end -%>
 


### PR DESCRIPTION
`docker kill` sends SIGKILL to running container

`docker stop` sends SIGTERM signal to running container, waits for timeout (10 seconds default)
and then sends SIGKILL

Killing container right away seems not to be a good idea, because it can interrupt some cleanup process, writing to files, broke DBs and etc.

`stop` was changed to `kill` in c2ea3e5d2db6dde9fdec2138efe711df1490b471 and motivation was to mimic init.d behavior, but init.d is not doing kill, see [init.d#stop](https://github.com/garethr/garethr-docker/blob/master/templates/etc/init.d/docker-run.erb#L106).