### PR TITLE
Run `metadata_lint` rake task instead `metadata`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ begin
     :syntax,
     :lint,
     :parallel_spec,
-    :metadata,
+    :metadata_lint,
   ]
 rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
@@ -60,5 +60,5 @@ task :test => [
   :syntax,
   :lint,
   :spec,
-  :metadata,
+  :metadata_lint,
 ]


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs_spec_helper/commit/40546a44524a494142628010c6cab7dc9f24b991 commit removes metadata task and now we should run metadata_lint instead