### PR TITLE
Run daemon-reload on each service file change

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,7 +7,7 @@
 #   Which tcp port, if any, to bind the docker service to.
 #
 # [*ip_forward*]
-#   This flag interacts with the IP forwarding setting on 
+#   This flag interacts with the IP forwarding setting on
 #   your host system's kernel
 #
 # [*iptables*]
@@ -149,10 +149,10 @@ class docker::service (
           before  => $_manage_service,
         }
         exec { 'docker-systemd-reload-before-service':
-          path    => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
-          command => 'systemctl daemon-reload',
-          before  => $_manage_service,
-          unless  => "systemctl status ${service_name}",
+          path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+          command     => 'systemctl daemon-reload',
+          before      => $_manage_service,
+          refreshonly => true,
         }
       }
     }


### PR DESCRIPTION
We should run `systemctl daemon-reload` regardless of `systemctl docker status` command results,
but only if service-overrides.conf file was changed.