### PR TITLE
not all systems have Internet access, this provides an opportunity fo…

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -19,7 +19,7 @@
 #
 class docker::compose(
   $ensure = 'present',
-  $version = $docker::params::compose_version
+  $version = $docker::params::compose_version,
   $install_from = "https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64"
 ) inherits docker::params {
   validate_string($version)

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -13,9 +13,14 @@
 #   The version of Docker Compose to install.
 #   Defaults to the value set in $docker::params::compose_version
 #
+# [*install_from*]
+#   The URL to use to install docker-compose.
+#   Defaults to the URL recommended by https://docs.docker.com/compose/install/
+#
 class docker::compose(
   $ensure = 'present',
   $version = $docker::params::compose_version
+  $install_from = "https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64"
 ) inherits docker::params {
   validate_string($version)
   validate_re($ensure, '^(present|absent)$')
@@ -24,7 +29,7 @@ class docker::compose(
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > /usr/local/bin/docker-compose-${version}",
+      command => "curl -s -L ${install_from} > /usr/local/bin/docker-compose-${version}",
       creates => "/usr/local/bin/docker-compose-${version}"
     } ->
     file { "/usr/local/bin/docker-compose-${version}":

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -20,17 +20,25 @@
 class docker::compose(
   $ensure = 'present',
   $version = $docker::params::compose_version,
-  $install_url = "https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64"
+  $install_url = 'UNSET',
 ) inherits docker::params {
+  #referening parameter variables in parameters is randomly successful
+  #  see https://tickets.puppetlabs.com/browse/PUP-1080 for details
+  if $install_url == 'UNSET' {
+    $install_url_real = "https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64"
+  } else {
+    $install_url_real = $install_url
+  }
+
   validate_string($version)
   validate_re($ensure, '^(present|absent)$')
-  validate_re($install_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$')
+  validate_re($install_url_real, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$')
 
   if $ensure == 'present' {
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L ${install_url} > /usr/local/bin/docker-compose-${version}",
+      command => "curl -s -L ${install_url_real} > /usr/local/bin/docker-compose-${version}",
       creates => "/usr/local/bin/docker-compose-${version}"
     } ->
     file { "/usr/local/bin/docker-compose-${version}":

--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -13,23 +13,24 @@
 #   The version of Docker Compose to install.
 #   Defaults to the value set in $docker::params::compose_version
 #
-# [*install_from*]
+# [*install_url*]
 #   The URL to use to install docker-compose.
 #   Defaults to the URL recommended by https://docs.docker.com/compose/install/
 #
 class docker::compose(
   $ensure = 'present',
   $version = $docker::params::compose_version,
-  $install_from = "https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64"
+  $install_url = "https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64"
 ) inherits docker::params {
   validate_string($version)
   validate_re($ensure, '^(present|absent)$')
+  validate_re($install_url, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$')
 
   if $ensure == 'present' {
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L ${install_from} > /usr/local/bin/docker-compose-${version}",
+      command => "curl -s -L ${install_url} > /usr/local/bin/docker-compose-${version}",
       creates => "/usr/local/bin/docker-compose-${version}"
     } ->
     file { "/usr/local/bin/docker-compose-${version}":

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -8,19 +8,18 @@ describe 'docker::compose', :type => :class do
 
   context 'when no install_url is provided' do
     let(:params) { {:version => '1.5.2'} }
-    it { is_expected.to contain_class('docker::compose').with_install_url(
-           'https://github.com/docker/compose/releases/download/1.5.2/docker-compose-Linux-x86_64') }
-    it { is_expected.to contain_exec('Install Docker Compose 1.5.2').with_command('curl -s -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.5.2') }
+    it { is_expected.to contain_exec('Install Docker Compose 1.5.2').with_command(
+           'curl -s -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.5.2')
+    }
   end
 
   context 'when a new install_url is provided' do
     let(:params) { {:install_url => 'http://example.com/docker/compose/download/file',
-                   :version => '1.5.2'} }
+                    :version => '1.5.2'} }
     it { is_expected.to compile }
-    it { is_expected.to contain_class('docker::compose').with_install_url(
-           'http://example.com/docker/compose/download/file')
+    it { is_expected.to contain_exec('Install Docker Compose 1.5.2').with_command(
+           'curl -s -L http://example.com/docker/compose/download/file > /usr/local/bin/docker-compose-1.5.2')
     }
-    it { is_expected.to contain_exec('Install Docker Compose 1.5.2').with_command('curl -s -L http://example.com/docker/compose/download/file > /usr/local/bin/docker-compose-1.5.2') }
   end
 
   context 'when install_url is not a url' do

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'docker::compose', :type => :class do
+  it { is_expected.to compile }
+
+  let(:facts) { {:kernel => 'Linux'} }
+  let(:params) { {:version => '1.5.2'} }
+
+  context 'when no install_url is provided' do
+    it { is_expected.to contain_class('docker::compose').with_install_url(
+           'https://github.com/docker/compose/releases/download/1.5.2/docker-compose-Linux-x86_64') }
+    it { is_expected.to contain_exec('Install Docker Compose 1.5.2').with_command('curl -s -L https://github.com/docker/compose/releases/download/1.5.2/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.5.2') }
+  end
+
+  context 'when a new install_url is provided' do
+    let(:params) { {:install_url => 'http://example.com/docker/compose/download/file'} }
+
+    it { is_expected.to compile }
+
+    it { is_expected.to contain_class('docker::compose').with_install_url(
+           'http://example.com/docker/compose/download/file')
+    }
+    it { is_expected.to contain_exec('Install Docker Compose 1.5.2').with_command('curl -s -L http://example.com/docker/compose/download/file > /usr/local/bin/docker-compose-1.5.2') }
+  end
+
+  context 'when install_url is not a url' do
+    let(:params) { {:install_url => 'this is not a valid url' } }
+
+    it do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/does not match/)
+    end
+  end
+
+end

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -14,10 +14,9 @@ describe 'docker::compose', :type => :class do
   end
 
   context 'when a new install_url is provided' do
-    let(:params) { {:install_url => 'http://example.com/docker/compose/download/file', :version => '1.5.2'} }
-
+    let(:params) { {:install_url => 'http://example.com/docker/compose/download/file',
+                   :version => '1.5.2'} }
     it { is_expected.to compile }
-
     it { is_expected.to contain_class('docker::compose').with_install_url(
            'http://example.com/docker/compose/download/file')
     }
@@ -25,8 +24,7 @@ describe 'docker::compose', :type => :class do
   end
 
   context 'when install_url is not a url' do
-    let(:params) { {:install_url => 'this is not a valid url', :version => '1.5.2'} }
-
+    let(:params)  { {:install_url => 'this is not a URL'} }
     it do
       expect {
         is_expected.to compile


### PR DESCRIPTION
minor refactor to allow override of docker-compose URL (production systems in our environment don't have outgoing Internet access, and as such we deploy from an internal web host).

I know that this is a relatively common practice, so this small refactor allows for using an internal URL for docker-compose installation.
