### PR TITLE
Added docker_network wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,14 +368,14 @@ You can do that on the `docker` class like so:
 extra_parameters => '--cluster-store=<backend>://172.17.8.101:<port> --cluster-advertise=<interface>:2376'
 ```
 
-If using hiera, there's a `docker::network` class you can configure, for example:
+If using hiera, there's a `docker::networks` class you can configure, for example:
 
 ```yaml
 ---
   classes:
-    - docker::network
+    - docker::networks
 
-docker::network::network:
+docker::networks::networks:
   local-docker:
     ensure: 'present'
     subnet: '192.168.1.0/24'

--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ docker::image { 'ubuntu':
 If using hiera, there's a `docker::images` class you can configure, for example:
 
 ```yaml
-docker::images:
+---
+  classes:
+    - docker::images
+
+docker::images::images:
   ubuntu:
     image_tag: 'precise'
 ```
@@ -313,7 +317,7 @@ docker::run { 'helloworld':
 ```
 
 By default the generated init scripts will remove the container (but not
-any associated volumes) when the service is stoped or started. This
+any associated volumes) when the service is stopped or started. This
 behaviour can be modified using the following, with defaults shown:
 
 ```puppet
@@ -362,6 +366,20 @@ You can do that on the `docker` class like so:
 
 ```puppet
 extra_parameters => '--cluster-store=<backend>://172.17.8.101:<port> --cluster-advertise=<interface>:2376'
+```
+
+If using hiera, there's a `docker::network` class you can configure, for example:
+
+```yaml
+---
+  classes:
+    - docker::network
+
+docker::network::network:
+  local-docker:
+    ensure: 'present'
+    subnet: '192.168.1.0/24'
+    gateway: '192.168.1.1'
 ```
 
 ### Compose

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -1,4 +1,0 @@
-# docker::network
-class docker::networks($networks) {
-  create_resources(docker_network, $networks)
-}

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -1,0 +1,4 @@
+# docker::network
+class docker::network($network) {
+  create_resources(docker_network, $network)
+}

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -1,4 +1,4 @@
 # docker::network
-class docker::network($network) {
-  create_resources(docker_network, $network)
+class docker::networks($networks) {
+  create_resources(docker_network, $networks)
 }

--- a/manifests/networks.pp
+++ b/manifests/networks.pp
@@ -1,0 +1,4 @@
+# docker::networks
+class docker::networks($networks) {
+  create_resources(docker_network, $networks)
+}


### PR DESCRIPTION
Included a docker_network type wrapper for hiera.
Also improved the README regarding hiera usage because:

```
docker::images:
  ubuntu:
    image_tag: 'precise'
```

produces an error: `hiera::images: produces Error: Must pass images to Class[Docker::Images]`