### PR TITLE
Removing deprecated puppetlabs-apt properties to remove deprecation notices

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -27,15 +27,15 @@ class docker::repos {
       if ($docker::use_upstream_package_source) {
         ensure_packages(['debian-keyring', 'debian-archive-keyring'])
         apt::source { 'docker':
-          location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
-          key               => {
+          location => $location,
+          release  => $docker::package_release,
+          repos    => $docker::package_repos,
+          key      => {
             'id'     => $package_key,
             'server' => 'hkp://keyserver.ubuntu.com:80',
           },
-          pin               => '10',
-          require           => [
+          pin      => '10',
+          require  => [
             Package['debian-keyring'],
             Package['debian-archive-keyring'],
           ],

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -25,15 +25,20 @@ class docker::repos {
       }
       Exec['apt_update'] -> Package[$docker::prerequired_packages]
       if ($docker::use_upstream_package_source) {
+        ensure_packages(['debian-keyring', 'debian-archive-keyring'])
         apt::source { 'docker':
           location          => $location,
           release           => $docker::package_release,
           repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
-          required_packages => 'debian-keyring debian-archive-keyring',
+          key               => {
+            'id'     => $package_key,
+            'server' => 'hkp://keyserver.ubuntu.com:80',
+          },
           pin               => '10',
-          include_src       => false,
+          require           => [
+            Package['debian-keyring'],
+            Package['debian-archive-keyring'],
+          ],
         }
         if $docker::manage_package {
           Apt::Source['docker'] -> Package['docker']


### PR DESCRIPTION
The `key_source` and `required_packages` properties are deprecated and `key` should now be a hash instead of a string. I'm not sure the best way to handle the required packages so I've moved them to an `ensure_packages` call for now and made that a requirement of the apt resource.

Addresses #455.
