### PR TITLE
Updates `--cpuset` to `--cpuset-cpus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ docker::run { 'helloworld':
   volumes         => ['/var/lib/couchdb', '/var/log'],
   volumes_from    => '6446ea52fbc9',
   memory_limit    => '10m', # (format: '<number><unit>', where unit = b, k, m or g)
-  cpuset          => ['0', '3'],
+  cpuset          => ['0', '3'], # Docker < 1.10
+  cpuset_cpus     => ['0', '3'], # Docker >= 1.10
   username        => 'example',
   hostname        => 'example.com',
   env             => ['FOO=BAR', 'FOO2=BAR2'],

--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -26,6 +26,12 @@ module Puppet::Parser::Functions
       flags << "-m #{opts['memory_limit']}"
     end
 
+    cpuset_cpus = [opts['cpuset_cpus']].flatten.compact
+    unless cpuset_cpus.empty?
+      value = cpuset_cpus.join(',')
+      flags << "--cpuset-cpus=#{value}"
+    end
+
     cpusets = [opts['cpuset']].flatten.compact
     unless cpusets.empty?
       value = cpusets.join(',')

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -49,6 +49,7 @@ define docker::run(
   $command = undef,
   $memory_limit = '0b',
   $cpuset = [],
+  $cpuset_cpus = [],
   $ports = [],
   $labels = [],
   $expose = [],
@@ -152,8 +153,13 @@ define docker::run(
   $depends_array = any2array($depends)
   $depend_services_array = any2array($depend_services)
 
+  if (!empty($cpuset) and !empty($cpuset_cpus)) {
+    fail("You have arguments for both \$cpuset(${cpuset}) and \$cpuset_cpus(${cpuset_cpus}), pick one. Note: cpuset was deprecated in Docker 1.8 and removed in docker 1.10")
+  }
+
   $docker_run_flags = docker_run_flags({
     cpuset          => any2array($cpuset),
+    cpuset_cpus     => any2array($cpuset_cpus),
     detach          => $valid_detach,
     disable_network => $disable_network,
     dns             => any2array($dns),

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -247,6 +247,30 @@ require 'spec_helper'
       it { should contain_file(initscript).without_content(/--cpuset=/) }
     end
 
+    context 'when not passing a cpuset-cpus arg' do
+      let(:params) { {'command' => 'command', 'image' => 'base'} }
+      it { should contain_file(initscript).without_content(/--cpuset-cpus=/) }
+    end
+
+    context 'when passing a cpuset-cpus arg' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset_cpus' => '3'} }
+      it { should contain_file(initscript).with_content(/--cpuset-cpus=3/) }
+    end
+
+    context 'when passing a multiple args for cpuset-cpus' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset_cpus' => ['0', '3']} }
+      it { should contain_file(initscript).with_content(/--cpuset-cpus=0,3/) }
+    end
+
+    context 'when passing both cpuset-cpus and cpuset args' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => ['0', '3'], 'cpuset_cpus' => ['0', '3']} }
+      it do
+        expect {
+          should contain_file(initscript)
+        }.to raise_error(Puppet::Error,/You have arguments for both \$cpuset\(03\) and \$cpuset_cpus\(03\), pick one. Note: cpuset was deprecated in Docker 1.8 and removed in docker 1.10/)
+      end
+    end
+
     context 'when passing a links option' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'links' => ['example:one', 'example:two']} }
       it { should contain_file(initscript).with_content(/ --link example:one --link example:two /) }


### PR DESCRIPTION
- --cpuset was deprecated in 1.8.0, removed in 1.10.0
