### PR TITLE
Disabled extras repo if using upstream package source

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -183,7 +183,7 @@ class docker::params {
       }
 
       # repo_opt to specify install_options for docker package
-      if (versioncmp($::operatingsystemmajrelease, '7') == 0) {
+      if (versioncmp($::operatingsystemmajrelease, '7') == 0 and $::use_upstream_package_source == false) {
         if $::operatingsystem == 'RedHat' {
           $repo_opt = '--enablerepo=rhel7-extras'
         } elsif $::operatingsystem == 'CentOS' {


### PR DESCRIPTION
When using the upstream package source you don't need the extras repository enabled (and probably shouldn't have it enabled) during the install.
