### PR TITLE
Disable gpgcheck if gpgkey is blank

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -193,7 +193,7 @@ class docker::params {
       }
 
       # repo_opt to specify install_options for docker package
-      if (versioncmp($::operatingsystemmajrelease, '7') == 0) {
+      if (versioncmp($::operatingsystemmajrelease, '7') == 0 and $::use_upstream_package_source == false) {
         if $::operatingsystem == 'RedHat' {
           $repo_opt = '--enablerepo=rhel7-extras'
         } elsif $::operatingsystem == 'CentOS' {

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -47,17 +47,21 @@ class docker::repos {
           $baseurl = $docker::package_source_location
           $gpgkey = $docker::package_key_source
         }
-        if ($gpgkey == '') {
-            $gpgcheck = '0'
-        } else {
-            $gpgcheck = '1'
-        }
         if ($docker::use_upstream_package_source) {
-          yumrepo { 'docker':
-            descr    => 'Docker',
-            baseurl  => $baseurl,
-            gpgkey   => $gpgkey,
-            gpgcheck => $gpgcheck,
+          if $gpgkey =~ /([Aa]bsent|[Ff]alse)/ {
+            yumrepo { 'docker':
+              descr    => 'Docker',
+              baseurl  => $baseurl,
+              gpgkey   => absent,
+              gpgcheck => False,
+            }
+          } else {
+            yumrepo { 'docker':
+              descr    => 'Docker',
+              baseurl  => $baseurl,
+              gpgkey   => $gpgkey,
+              gpgcheck => $gpgcheck,
+            }
           }
           Yumrepo['docker'] -> Package['docker']
         }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -47,12 +47,17 @@ class docker::repos {
           $baseurl = $docker::package_source_location
           $gpgkey = $docker::package_key_source
         }
+        if ($gpgkey == '') {
+            $gpgcheck = '0'
+        } else {
+            $gpgcheck = '1'
+        }
         if ($docker::use_upstream_package_source) {
           yumrepo { 'docker':
             descr    => 'Docker',
             baseurl  => $baseurl,
             gpgkey   => $gpgkey,
-            gpgcheck => true,
+            gpgcheck => $gpgcheck,
           }
           Yumrepo['docker'] -> Package['docker']
         }


### PR DESCRIPTION
When specifying a alternate installation repo I don't always want gpgcheck enabled. This disables gpgcheck if the gpgkey is set to an empty string.

I'm using this via hiera such as

``` ---
docker::package_source_location: 'file:///usr/local/repo/mirrors/docker-7-x86_64'
docker::package_key_source: ''
docker::package_name: 'docker-engine'
```

This will generate the following docker.repo file

```
# docker.repo 
[docker]
name=Docker
baseurl=file:///usr/local/repo/mirrors/docker-7-x86_64
gpgcheck=0
enabled=1
gpgkey=
```

Optionally we could remove the gpgkey line completely but it would only add more to the if statement.

An alternative approach would be to have the template generate each key = value in the repo but that would add even more variables which I think there are already enough.
