### PR TITLE
Add support for docker's --bip and --mtu options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,14 @@
 #   Enable IP masquerading for bridge's IP range.
 #   The default is true.
 #
+# [*bip*]
+#   Specify docker's network bridge IP, in CIDR notation.
+#   Defaults to undefined.
+#
+# [*mtu*]
+#   Docker network MTU.
+#   Defaults to undefined.
+#
 # [*bridge*]
 #   Attach containers to a pre-existing network bridge 
 #   use 'none' to disable container networking
@@ -290,6 +298,8 @@ class docker(
   $tcp_bind                          = $docker::params::tcp_bind,
   $ip_forward                        = $docker::params::ip_forward,
   $ip_masq                           = $docker::params::ip_masq,
+  $bip                               = $docker::params::bip,
+  $mtu                               = $docker::params::mtu,
   $iptables                          = $docker::params::iptables,
   $socket_bind                       = $docker::params::socket_bind,
   $fixed_cidr                        = $docker::params::fixed_cidr,
@@ -378,6 +388,7 @@ class docker(
   validate_string($bridge)
   validate_string($fixed_cidr)
   validate_string($default_gateway)
+  validate_string($bip)
 
   if ($fixed_cidr or $default_gateway) and (!$bridge) {
     fail('You must provide the $bridge parameter.')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,8 @@ class docker::params {
   $ip_forward                        = true
   $iptables                          = true
   $ip_masq                           = true
+  $bip                               = undef
+  $mtu                               = undef
   $fixed_cidr                        = undef
   $bridge                            = undef
   $default_gateway                   = undef

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -21,6 +21,8 @@ other_args="<% -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
+<% if @bip %> --bip=<%= @bip %> <% end -%>
+<% if @mtu %> --mtu=<%= @mtu %> <% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>"
 
 <% if @proxy %>export http_proxy='<%= @proxy %>'

--- a/templates/etc/sysconfig/docker.systemd.erb
+++ b/templates/etc/sysconfig/docker.systemd.erb
@@ -18,6 +18,8 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
 <% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
+<% if @bip %> --bip=<%= @bip %> <% end -%>
+<% if @mtu %> --mtu=<%= @mtu %> <% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>"
 
 <% if @proxy %>http_proxy='<%= @proxy %>'


### PR DESCRIPTION
This may be needed to support software defined networks like flanneld,
or other custom network setups.