### PR TITLE
Give the possibility to override create_user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,5 +1,9 @@
 # == Class: docker::config
 #
-class docker::config {
-  docker::system_user { $docker::docker_users: }
+class docker::config (
+  $create_user = true
+){
+  docker::system_user { $docker::docker_users:
+    create_user => $create_user
+  }
 }


### PR DESCRIPTION
`create_user` is currently with default true and there was no way to
override this behaviour.

With this change we give the possibility to override the `create_user` value using
puppet automatic parameter lookup on the docker::config class.