### PR TITLE
Missing params variables

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class docker::params {
   $service_state                     = running
   $service_enable                    = true
   $service_provider                  = undef
+  $service_overrides_template        = undef
   $manage_service                    = true
   $root_dir                          = undef
   $tmp_dir                           = '/tmp/'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class docker::params {
   $socket_group                      = undef
   $service_state                     = running
   $service_enable                    = true
+  $service_provider                  = undef
   $manage_service                    = true
   $root_dir                          = undef
   $tmp_dir                           = '/tmp/'


### PR DESCRIPTION
Some variables are used in both init.pp and params.pp but are not initialized correctly.