### PR TITLE
Ensure that containers are restart after the docker restarts

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -26,6 +26,11 @@
 #   (optional) Whether or not to restart the service if the the generated init
 #   script changes.  Default: true
 #
+# [*restart_service_on_docker_refresh*]
+#   Whether or not to restart the service if the docker service is restarted.
+#   Only has effect if the docker_service parameter is set.
+#   Default: true
+#
 # [*manage_service*]
 #  (optional) Whether or not to create a puppet Service resource for the init
 #  script.  Disabling this may be useful if integrating with existing modules.
@@ -67,6 +72,7 @@ define docker::run(
   $lxc_conf = [],
   $service_prefix = 'docker-',
   $restart_service = true,
+  $restart_service_on_docker_refresh = true,
   $manage_service = true,
   $docker_service = false,
   $disable_network = false,
@@ -116,6 +122,7 @@ define docker::run(
   validate_bool($disable_network)
   validate_bool($privileged)
   validate_bool($restart_service)
+  validate_bool($restart_service_on_docker_refresh)
   validate_bool($tty)
   validate_bool($remove_container_on_start)
   validate_bool($remove_container_on_stop)
@@ -327,8 +334,14 @@ define docker::run(
         if $docker_service {
           if $docker_service == true {
             Service['docker'] -> Service["${service_prefix}${sanitised_title}"]
+            if $restart_service_on_docker_refresh == true {
+              Service['docker'] ~> Service["${service_prefix}${sanitised_title}"]
+            }
           } else {
             Service[$docker_service] -> Service["${service_prefix}${sanitised_title}"]
+            if $restart_service_on_docker_refresh == true {
+              Service[$docker_service] ~> Service["${service_prefix}${sanitised_title}"]
+            }
           }
         }
       }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -632,10 +632,26 @@ require 'spec_helper'
 			let(:pre_condition) { "service { 'docker': }" }
       it { should compile.with_all_deps }
 			it { should contain_service('docker').that_comes_before('Service[docker-sample]') }
+			it { should contain_service('docker').that_notifies('Service[docker-sample]') }
+    end
+
+    context 'when `docker_service` is true and `restart_service_on_docker_refresh` is false' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => true, 'restart_service_on_docker_refresh' => false} }
+			let(:pre_condition) { "service { 'docker': }" }
+      it { should compile.with_all_deps }
+			it { should contain_service('docker').that_comes_before('Service[docker-sample]') }
     end
 
     context 'when `docker_service` is `my-docker`' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => 'my-docker'} }
+			let(:pre_condition) { "service{ 'my-docker': }" }
+      it { should compile.with_all_deps }
+			it { should contain_service('my-docker').that_comes_before('Service[docker-sample]') }
+			it { should contain_service('my-docker').that_notifies('Service[docker-sample]') }
+    end
+
+    context 'when `docker_service` is `my-docker` and `restart_service_on_docker_refresh` is false' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'docker_service' => 'my-docker', 'restart_service_on_docker_refresh' => false} }
 			let(:pre_condition) { "service{ 'my-docker': }" }
       it { should compile.with_all_deps }
 			it { should contain_service('my-docker').that_comes_before('Service[docker-sample]') }


### PR DESCRIPTION
If the module decides to reload the docker daemon then all containers are stopped,
this change ensures that all containers are started after the refresh of the service.

The functionality can be disabled with the restart_service_on_docker_refresh parameter in docker::run.
For it to work the docker_service parameter needs to be set, indicating that the docker daemon is managed by this module.
