### PR TITLE
Avoid "invalid byte sequence" error

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -150,7 +150,7 @@ class docker::service (
         }
         exec { 'docker-systemd-reload-before-service':
           path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
-          command     => 'systemctl daemon-reload',
+          command     => 'systemctl daemon-reload > /dev/null',
           before      => $_manage_service,
           refreshonly => true,
         }


### PR DESCRIPTION
Fix #452 by throwing the unexpected multi-byte service status output to /dev/null