### PR TITLE
Systemd Service Overrides for Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -82,6 +82,7 @@ class docker::params {
             $service_provider        = 'systemd'
             $storage_config          = '/etc/default/docker-storage'
             $service_config_template = 'docker/etc/sysconfig/docker.systemd.erb'
+            $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
             $service_hasstatus       = true
             $service_hasrestart      = true
             include docker::systemd_reload


### PR DESCRIPTION
The system service overrides file was only used on Debian versions with systemd not Ubuntu. This causes none of the options in /etc/default/docker to work when systemd is used to start the service.

Thanks
Sam