### PR TITLE
fixed: refresh on docker::image should rebuild the image

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -107,6 +107,17 @@ define docker::image(
       returns     => ['0', '1'],
       require     => File['/usr/local/bin/update_docker_image.sh'],
     }
+
+    exec { "refresh - ${image_install}":
+      command     => $image_install,
+      refreshonly => true,
+      onlyif      => $image_find,
+      environment => 'HOME=/root',
+      path        => ['/bin', '/usr/bin'],
+      timeout     => 0,
+      returns     => ['0', '1'],
+      require     => File['/usr/local/bin/update_docker_image.sh'],
+    }
   }
 
 }

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -92,7 +92,7 @@ describe 'the Puppet Docker module' do
     end
 
     describe 'docker::image' do
-      
+
       it 'should successfully download an image from the Docker Hub' do
         pp=<<-EOS
           class { 'docker':}
@@ -247,6 +247,47 @@ describe 'the Puppet Docker module' do
 
         shell('docker images') do |r|
           expect(r.stdout).to_not match(/busybox/)
+        end
+      end
+
+      it 'should rebuild when refreshed' do
+        pp1=<<-EOS
+          class { 'docker':}
+
+          docker::image { 'ubuntu_with_file':
+            docker_file => "/root/Dockerfile",
+            require     => Class['docker'],
+            subscribe => File["/root/Dockerfile"],
+          }
+
+          file { '/root/Dockerfile':
+            ensure  => present,
+            content => "FROM busybox\nRUN echo 1 > /root/test_file_from_dockerfile.txt",
+            before  => Docker::Image['ubuntu_with_file'],
+          }
+        EOS
+        apply_manifest(pp1, :catch_failures => true)
+        pp2=<<-EOS
+          class { 'docker':}
+
+          docker::image { 'ubuntu_with_file':
+            docker_file => "/root/Dockerfile",
+            require     => Class['docker'],
+            subscribe => File["/root/Dockerfile"],
+          }
+
+          file { '/root/Dockerfile':
+            ensure  => present,
+            content => "FROM busybox\nRUN echo 2 > /root/test_file_from_dockerfile.txt",
+            before  => Docker::Image['ubuntu_with_file'],
+          }
+        EOS
+
+        apply_manifest(pp2, :catch_failures => true)
+        apply_manifest(pp2, :catch_changes => true) unless fact('selinux') == 'true'
+
+        shell("docker run ubuntu_with_file cat /root/test_file_from_dockerfile.txt") do |r|
+          expect(r.stdout).to match(/2/)
         end
       end
     end


### PR DESCRIPTION
Refrehes on docker::image wouldn't rebuild the image. The culprit is the `unless` parameter in the install `exec`:

```
    exec { $image_install:
      unless      => $image_find,
...
```

My solution is not that elegant, but should work: I added a clone of the `exec` which will only run on refreshes and only if the image is found.

Another solution would be to add an `exec` for the image_find which would run every time and refresh the image_install if no image is found. Something like this:

```
exec { $image_find:
  command => 'true',
  unless => $image_find,
  notify => Exec[$image_install],
}
```

That way the original exec could change to `refreshonly` without the `unless`.
