### PR TITLE
feat(docker::run): add the enable param

### DIFF
--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -92,7 +92,7 @@ describe 'the Puppet Docker module' do
     end
 
     describe 'docker::image' do
-      
+
       it 'should successfully download an image from the Docker Hub' do
         pp=<<-EOS
           class { 'docker':}
@@ -484,7 +484,7 @@ describe 'the Puppet Docker module' do
             require => Class['docker'],
           }
 
-          docker::run { 'container_3_6':
+          docker::run { 'container_3_7':
             image   => 'ubuntu',
             command => 'init',
             require => Docker::Image['ubuntu'],
@@ -498,7 +498,7 @@ describe 'the Puppet Docker module' do
             require => Class['docker'],
           }
 
-          docker::run { 'container_3_6':
+          docker::run { 'container_3_7':
             ensure  => 'absent',
             image   => 'ubuntu',
             require => Docker::Image['ubuntu'],
@@ -511,7 +511,7 @@ describe 'the Puppet Docker module' do
         # A sleep to give docker time to execute properly
         sleep 4
 
-        shell('docker inspect container-3-6', :acceptable_exit_codes => [0])
+        shell('docker inspect container-3-7', :acceptable_exit_codes => [0])
 
         apply_manifest(pp2, :catch_failures => true)
         apply_manifest(pp2, :catch_changes => true) unless fact('selinux') == 'true'
@@ -519,7 +519,48 @@ describe 'the Puppet Docker module' do
         # A sleep to give docker time to execute properly
         sleep 4
 
-        shell('docker inspect container-3-6', :acceptable_exit_codes => [1])
+        shell('docker inspect container-3-7', :acceptable_exit_codes => [1])
+
+        if fact('osfamily') == 'RedHat'
+          shell('systemctl is-enabled docker-container-3-7', :acceptable_exit_codes => [1]) do |r|
+            expect(r.stdout).to match('disabled')
+          end
+        else
+          shell('ls /etc/init.d/docker-container-3-7.override | wc -l') do |r|
+            expect(r.stdout).to match(/^1$/)
+          end
+        end
+      end
+
+      it 'should allow you to enable a container but not start it' do
+        pp=<<-EOS
+          class { 'docker':}
+
+          docker::image { 'ubuntu':
+            require => Class['docker'],
+          }
+
+          docker::run { 'container_3_8':
+            image   => 'ubuntu',
+            command => 'init',
+            running => false,
+            enable  => true,
+            require => Docker::Image['ubuntu'],
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true) unless fact('selinux') == 'true'
+
+        shell('docker ps | wc -l') do |r|
+          expect(r.stdout).to match(/^1$/)
+        end
+
+        if fact('osfamily') == 'RedHat'
+          shell('systemctl is-enabled docker-container-3-8') do |r|
+            expect(r.stdout).to match('enabled')
+          end
+        end
       end
     end
 
@@ -569,4 +610,3 @@ describe 'the Puppet Docker module' do
     end
   end
 end
-

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -249,6 +249,19 @@ require 'spec_helper'
     context 'when stopping the service' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'running' => false} }
       it { should contain_service('docker-sample').with_ensure(false) }
+      it { should contain_service('docker-sample').with_enable(false) }
+    end
+
+    context 'when stopping the service and it needs to remain enabled' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'running' => false, 'enable' => true} }
+      it { should contain_service('docker-sample').with_ensure(false) }
+      it { should contain_service('docker-sample').with_enable(true) }
+    end
+
+    context 'when disabling the service' do
+      # running defaults to true
+      let(:params) {{ 'command' => 'command', 'image' => 'base', 'enable' => false} }
+      it { should contain_service('docker-sample').with_enable(false) }
     end
 
     context 'when passing a memory limit in bytes' do


### PR DESCRIPTION
Here is a possible answer to https://github.com/garethr/garethr-docker/issues/308.  All tests passing with the exception of one unrelated beaker test.  I confirmed that this test is failing sans this code change.  

```
spec/acceptance/docker_spec.rb:114 # docker registry should be able to login to the registry
```

Whether or not this can be merged, feedback would be greatly appreciated!  I would be happy to make suggested changes and update the PR so we can get this functionality added to the module.

Thanks for the great work.

- Reppard