### PR TITLE
Fix docker run when using docker swarm

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -65,8 +65,7 @@ module Puppet::Parser::Functions
       ['-p %s',             'ports'],
       ['-l %s',             'labels'],
       ['--add-host %s',     'hostentries'],
-      ['-v %s',             'volumes'],
-      ['-H %s',             'socket_connect'],
+      ['-v %s',             'volumes']
     ].each do |(format, key)|
       values    = opts[key]
       new_flags = multi_flags.call(values, format)

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -97,7 +97,12 @@ define docker::run(
   $remove_volume_on_stop = false,
 ) {
   include docker::params
-  $docker_command = $docker::params::docker_command
+  if ($socket_connect != []) {
+    $sockopts = join(any2array($socket_connect), ',')
+    $docker_command = "${docker::params::docker_command} -H ${sockopts}"
+  }else {
+    $docker_command = $docker::params::docker_command
+  }
   $service_name = $docker::params::service_name
 
   validate_re($image, '^[\S]*$')


### PR DESCRIPTION
docker only accepts -H before the subcommand on recent versions.
In order to fix this I've removed socket_connect from the run flags and added
it to the docker_command variable.

This has the added benefit of prefixing every command for docker
run in the init scripts, with the socket_connect option. This can
prevent weird situations where docker stop/kill will run against a container
the local docker swarm node doesn't know about.