### PR TITLE
Re-enabled lint check case_without_default 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,6 @@ end
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.disable_80chars
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
-PuppetLint.configuration.disable_case_without_default
 PuppetLint.configuration.fail_on_warnings = true
 
 # Forsake support for Puppet 2.6.2 for the benefit of cleaner code.

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -64,5 +64,6 @@ class docker::repos {
         }
       }
     }
+    default: {}
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -171,6 +171,7 @@ class docker::service (
         notify => $_manage_service,
       }
     }
+    default: {}
   }
 
   if $storage_config {


### PR DESCRIPTION
Small change to obey this style guide requirement:
- https://docs.puppet.com/guides/style_guide.html#defaults-for-case-statements-and-selectors
- http://puppet-lint.com/checks/case_without_default/