### PR TITLE
allow --bip and --fixed-cidr together

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -417,7 +417,7 @@ class docker(
   validate_string($default_gateway)
   validate_string($bip)
 
-  if ($fixed_cidr or $default_gateway) and (!$bridge) {
+  if ($default_gateway) and (!$bridge) {
     fail('You must provide the $bridge parameter.')
   }
 


### PR DESCRIPTION
if using --fixed-cidr and you want a fixed --bip,
you can not specify --bridge due to docker making
those options mutually exclusive.

for example, this hiera data:
docker::fixed_cidr: '172.16.16.0/22'
docker::bip:        '172.16.16.1/22'

will fail with:
Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Evaluation Error: Error while evaluating a Function Call, You
must provide the $bridge parameter.

specifying docker::bridge results in:
FATA[0000] Error starting daemon: You specified -b & --bip, mutually
exclusive options. Please specify only one.

the docker docs suggest "--fixed-cidr" and "--bip" together under the "Customizing docker0" section:
https://docs.docker.com/v1.5/articles/networking/#customizing-docker0