### PR TITLE
Added support for splunk to log driver

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,6 +108,8 @@
 #                Writes log messages to a GELF endpoint: Graylog or Logstash.
 #     fluentd  : Fluentd logging driver for Docker.
 #                Writes log messages to fluentd (forward input).
+#     splunk   : Splunk logging driver for Docker.
+#                Writes log messages to Splunk (HTTP Event Collector).
 #
 # [*log_opt*]
 #   Set the log driver specific options
@@ -135,6 +137,9 @@
 #                fluentd-tag={{.ID}} - short container id (12 characters)|
 #                            {{.FullID}} - full container id
 #                            {{.Name}} - container name
+#     splunk   :
+#                splunk-token=<splunk_http_event_collector_token>
+#                splunk-url=https://your_splunk_instance:8088
 #
 # [*selinux_enabled*]
 #   Enable selinux support. Default is false. SELinux does  not  presently
@@ -426,7 +431,7 @@ class docker(
   }
 
   if $log_driver {
-    validate_re($log_driver, '^(none|json-file|syslog|journald|gelf|fluentd)$', 'log_driver must be one of none, json-file, syslog, journald, gelf or fluentd')
+    validate_re($log_driver, '^(none|json-file|syslog|journald|gelf|fluentd|splunk)$', 'log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk')
   }
 
   if $selinux_enabled {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -585,7 +585,7 @@ describe 'docker', :type => :class do
         it do
           expect {
             should contain_package('docker')
-          }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, journald, gelf or fluentd/)
+          }.to raise_error(Puppet::Error, /log_driver must be one of none, json-file, syslog, journald, gelf, fluentd or splunk/)
         end
       end
 


### PR DESCRIPTION
Due to input validation you can not use the splunk or any new log drivers.
Rather than rip it out as I guess it was wanted, I have added the new splunk log driver in to the validator.