### PR TITLE
Add Docker Daemon's ICC parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pkg
 .vagrant
 .yardoc
 doc
+.idea/
 *.swp
 .ruby-version
 log

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,11 @@
 #   Enable IP masquerading for bridge's IP range.
 #   The default is true.
 #
+# [*icc*]
+#   Enable or disable Docker's unrestricted inter-container and Docker daemon host communication.
+#   (Requires iptables=true to disable)
+#   Default is undef. (Docker daemon's default is true)
+#
 # [*bip*]
 #   Specify docker's network bridge IP, in CIDR notation.
 #   Defaults to undefined.
@@ -326,6 +331,7 @@ class docker(
   $bip                               = $docker::params::bip,
   $mtu                               = $docker::params::mtu,
   $iptables                          = $docker::params::iptables,
+  $icc                               = $docker::params::icc,
   $socket_bind                       = $docker::params::socket_bind,
   $fixed_cidr                        = $docker::params::fixed_cidr,
   $bridge                            = $docker::params::bridge,
@@ -412,6 +418,9 @@ class docker(
   validate_bool($ip_forward)
   validate_bool($iptables)
   validate_bool($ip_masq)
+  if $icc != undef {
+    validate_bool($icc)
+  }
   validate_string($bridge)
   validate_string($fixed_cidr)
   validate_string($default_gateway)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class docker::params {
   $tls_key                           = '/etc/docker/tls/key.pem'
   $ip_forward                        = true
   $iptables                          = true
+  $icc                               = undef
   $ip_masq                           = true
   $bip                               = undef
   $mtu                               = undef

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -44,6 +44,7 @@ class docker::service (
   $ip_forward                        = $docker::ip_forward,
   $iptables                          = $docker::iptables,
   $ip_masq                           = $docker::ip_masq,
+  $icc                               = $docker::icc,
   $bridge                            = $docker::bridge,
   $fixed_cidr                        = $docker::fixed_cidr,
   $default_gateway                   = $docker::default_gateway,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -52,6 +52,8 @@ describe 'docker', :type => :class do
         it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo') }
         it { should contain_package('docker').with_install_options(nil) }
 
+        it { should contain_file('/etc/default/docker').without_content(/icc=/) }
+
         context 'with a custom version' do
           let(:params) { {'version' => '0.5.5' } }
           it { should contain_package('docker').with_ensure('0.5.5').with_name('docker-engine') }
@@ -88,6 +90,11 @@ describe 'docker', :type => :class do
         context 'with iptables param set to false' do
           let(:params) {{ 'iptables' => false }}
           it { should contain_file('/etc/default/docker').with_content(/iptables=false/) }
+        end
+
+        context 'with icc param set to false' do
+          let(:params) {{ 'icc' => false }}
+          it { should contain_file('/etc/default/docker').with_content(/icc=false/) }
         end
 
         context 'with tcp_bind array param' do
@@ -175,6 +182,8 @@ describe 'docker', :type => :class do
         service_config_file = '/etc/sysconfig/docker'
         storage_config_file = '/etc/sysconfig/docker-storage'
 
+        it { should contain_file('/etc/sysconfig/docker').without_content(/icc=/) }
+
         context 'with proxy param' do
           let(:params) { {'proxy' => 'http://127.0.0.1:3128' } }
           it { should contain_file(service_config_file).with_content(/export http_proxy='http:\/\/127.0.0.1:3128'/) }
@@ -204,6 +213,11 @@ describe 'docker', :type => :class do
         context 'with iptables param set to false' do
           let(:params) {{ 'iptables' => false }}
           it { should contain_file('/etc/sysconfig/docker').with_content(/iptables=false/) }
+        end
+
+        context 'with icc param set to false' do
+          let(:params) {{ 'icc' => false }}
+          it { should contain_file('/etc/sysconfig/docker').with_content(/icc=false/) }
         end
 
         context 'with tcp_bind array param' do
@@ -376,6 +390,8 @@ describe 'docker', :type => :class do
       it { should contain_class('docker::install').that_comes_before('docker::config') }
       it { should contain_class('docker::service').that_subscribes_to('docker::config') }
       it { should contain_class('docker::config') }
+
+      it { should contain_file(service_config_file).without_content(/icc=/) }
 
       context 'with a specific docker command' do
         let(:params) {{ 'docker_command' => 'docker.io' }}

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -11,6 +11,7 @@ other_args="<% -%>
  --ip-forward=<%= @ip_forward -%>
  --iptables=<%= @iptables -%>
  --ip-masq=<%= @ip_masq -%>
+<% unless @icc == nil %> --icc=<%= @icc %><% end -%>
 <% if @fixed_cidr %> --fixed-cidr <%= @fixed_cidr %><% end -%>
 <% if @default_gateway %> --default-gateway <%= @default_gateway %><% end -%>
 <% if @bridge %> --bridge <%= @bridge %><% end -%>

--- a/templates/etc/conf.d/docker.gentoo.erb
+++ b/templates/etc/conf.d/docker.gentoo.erb
@@ -11,6 +11,7 @@ DOCKER_OPTS="<% -%>
  --ip-forward=<%= @ip_forward -%>
  --iptables=<%= @iptables -%>
  --ip-masq=<%= @ip_masq -%>
+<% unless @icc == nil %> --icc=<%= @icc %><% end -%>
 <% if @fixed_cidr %> --fixed-cidr <%= @fixed_cidr %><% end -%>
 <% if @default_gateway %> --default-gateway <%= @default_gateway %><% end -%>
 <% if @bridge %> --bridge <%= @bridge %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -26,6 +26,7 @@ DOCKER_OPTS="\
  --ip-forward=<%= @ip_forward -%>
  --iptables=<%= @iptables -%>
  --ip-masq=<%= @ip_masq -%>
+<% unless @icc == nil %> --icc=<%= @icc %><% end -%>
 <% if @fixed_cidr %> --fixed-cidr <%= @fixed_cidr %><% end -%>
 <% if @bridge %> --bridge <%= @bridge %><% end -%>
 <% if @default_gateway %> --default-gateway <%= @default_gateway %><% end -%>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -11,6 +11,7 @@ other_args="<% -%>
  --ip-forward=<%= @ip_forward -%>
  --iptables=<%= @iptables -%>
  --ip-masq=<%= @ip_masq -%>
+<% unless @icc == nil %> --icc=<%= @icc %><% end -%>
 <% if @fixed_cidr %> --fixed-cidr <%= @fixed_cidr %><% end -%>
 <% if @bridge %> --bridge <%= @bridge %><% end -%>
 <% if @default_gateway %> --default-gateway <%= @default_gateway %><% end -%>

--- a/templates/etc/sysconfig/docker.systemd.erb
+++ b/templates/etc/sysconfig/docker.systemd.erb
@@ -8,6 +8,7 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
  --ip-forward=<%= @ip_forward -%>
  --iptables=<%= @iptables -%>
  --ip-masq=<%= @ip_masq -%>
+<% unless @icc == nil %> --icc=<%= @icc %><% end -%>
 <% if @fixed_cidr %> --fixed-cidr <%= @fixed_cidr %><% end -%>
 <% if @default_gateway %> --default-gateway <%= @default_gateway %><% end -%>
 <% if @bridge %> --bridge <%= @bridge %><% end -%>


### PR DESCRIPTION
To control unrestricted inter-container and Docker daemon host communication (with iptables).

Default is true, but we will only set it if specified by user.