### PR TITLE
Use the registry resource title for auth

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -54,7 +54,7 @@ define docker::registry(
       $auth_cmd = "${docker_command} logout ${server}"
   }
 
-  exec { "auth against ${server}":
+  exec { "${title} auth":
     environment => $auth_environment,
     command     => $auth_cmd,
     user        => $local_user,

--- a/spec/defines/registry_spec.rb
+++ b/spec/defines/registry_spec.rb
@@ -2,46 +2,46 @@ require 'spec_helper'
 
 describe 'docker::registry', :type => :define do
   let(:title) { 'localhost:5000' }
-  it { should contain_exec('auth against localhost:5000') }
+  it { should contain_exec('localhost:5000 auth') }
 
   context 'with ensure => present' do
     let(:params) { { 'ensure' => 'absent' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker logout localhost:5000') }
+    it { should contain_exec('localhost:5000 auth').with_command('docker logout localhost:5000') }
   end
 
   context 'with ensure => present' do
     let(:params) { { 'ensure' => 'present' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker login localhost:5000') }
+    it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and username => user1' do
     let(:params) { { 'ensure' => 'present', 'username' => 'user1' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker login localhost:5000') }
+    it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and password => secret' do
     let(:params) { { 'ensure' => 'present', 'password' => 'secret' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker login localhost:5000') }
+    it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and email => user1@example.io' do
     let(:params) { { 'ensure' => 'present', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command('docker login localhost:5000') }
+    it { should contain_exec('localhost:5000 auth').with_command('docker login localhost:5000') }
   end
 
   context 'with ensure => present and username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'ensure' => 'present', 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
   end
 
   context 'with username => user1, and password => secret and email => user1@example.io' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io' } }
-    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_environment('password=secret') }
   end
 
   context 'with username => user1, and password => secret, and email => user1@example.io and local_user => testuser' do
     let(:params) { { 'username' => 'user1', 'password' => 'secret', 'email' => 'user1@example.io', 'local_user' => 'testuser' } }
-    it { should contain_exec('auth against localhost:5000').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_user('testuser').with_environment('password=secret') }
+    it { should contain_exec('localhost:5000 auth').with_command("docker login -u 'user1' -p \"${password}\" -e 'user1@example.io' localhost:5000").with_user('testuser').with_environment('password=secret') }
   end
 
   context 'with an invalid ensure value' do


### PR DESCRIPTION
I have a use case where two different users need to register with the same registry. The old server-based naming of the auth resource wouldn't allow that, since the inner auth-exec had a duplicate title.

This changes the exec's title to be based on the surrounding resource's title, allowing manifests to make them unique if they want (otherwise it just defaults back to the server name).