### PR TITLE
update for compatibility with puppetlabs/apt >=2.0.0

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -27,15 +27,15 @@ class docker::repos {
       if ($docker::use_upstream_package_source) {
         ensure_packages(['debian-keyring', 'debian-archive-keyring'])
         apt::source { 'docker':
-          location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
-          key               => {
+          location => $location,
+          release  => $docker::package_release,
+          repos    => $docker::package_repos,
+          key      => {
             'id'     => $package_key,
             'server' => 'hkp://keyserver.ubuntu.com:80',
           },
-          pin               => '10',
-          require           => [
+          pin      => '10',
+          require  => [
             Package['debian-keyring'],
             Package['debian-archive-keyring'],
           ],

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -25,15 +25,20 @@ class docker::repos {
       }
       Exec['apt_update'] -> Package[$docker::prerequired_packages]
       if ($docker::use_upstream_package_source) {
+        ensure_packages(['debian-keyring', 'debian-archive-keyring'])
         apt::source { 'docker':
           location          => $location,
           release           => $docker::package_release,
           repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
-          required_packages => 'debian-keyring debian-archive-keyring',
+          key               => {
+            'id'     => $package_key,
+            'server' => 'hkp://keyserver.ubuntu.com:80',
+          },
           pin               => '10',
-          include_src       => false,
+          require           => [
+            Package['debian-keyring'],
+            Package['debian-archive-keyring'],
+          ],
         }
         if $docker::manage_package {
           Apt::Source['docker'] -> Package['docker']

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -31,7 +31,7 @@ class docker::repos {
             'id'     => $package_key,
             'server' => 'hkp://keyserver.ubuntu.com:80',
           },
-          pin      => '10',
+          pin      => 10,
           require  => [
             Package['debian-keyring'],
             Package['debian-archive-keyring'],

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -32,6 +32,7 @@ class docker::repos {
             'server' => 'hkp://keyserver.ubuntu.com:80',
           },
           pin      => {
+            order       => 10,
             priority    => 10,
             origin      => split($location, '/')[2]
           },

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -31,7 +31,10 @@ class docker::repos {
             'id'     => $package_key,
             'server' => 'hkp://keyserver.ubuntu.com:80',
           },
-          pin      => 10,
+          pin      => {
+            priority    => 10,
+            origin      => split($location, '/')[2]
+          },
           require  => [
             Package['debian-keyring'],
             Package['debian-archive-keyring'],


### PR DESCRIPTION
This PR builds on https://github.com/garethr/garethr-docker/pull/459 . 

I filed a bug with puppetlabs/apt to address the pin parameters. Setting pin without setting Order causes a validation error. This pull request is compatible with puppetlabs/apt 2.2.2. Ideally puppetlabs will address the validation error to simplify the apt::source parameters.
https://tickets.puppetlabs.com/browse/MODULES-3462
