### PR TITLE
add --time=<> to docker stop

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -95,6 +95,7 @@ define docker::run(
   $remove_container_on_stop = true,
   $remove_volume_on_start = false,
   $remove_volume_on_stop = false,
+  $stop_wait_time = 0,
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command
@@ -129,6 +130,8 @@ define docker::run(
   validate_bool($remove_volume_on_start)
   validate_bool($remove_volume_on_stop)
   validate_bool($use_name)
+
+  validate_integer($stop_wait_time)
 
   if ($remove_volume_on_start and !$remove_container_on_start) {
     fail("In order to remove the volume on start for ${title} you need to also remove the container")

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -113,7 +113,7 @@ stop() {
     <% if @before_stop -%>
         <%= @before_stop %>
     <% end -%>
-    $docker stop <%= @sanitised_title %>
+    $docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
     <% if @remove_container_on_stop -%>
         $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
     <% end -%>

--- a/templates/etc/init.d/docker-run.gentoo.erb
+++ b/templates/etc/init.d/docker-run.gentoo.erb
@@ -76,7 +76,7 @@ stop() {
     <% if @before_stop -%>
         <%= @before_stop %>
     <% end -%>
-    $docker stop <%= @sanitised_title %>
+    $docker stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
     <% if @remove_container_on_stop -%>
     $docker rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
     <% end -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -48,7 +48,7 @@ ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
 <% end -%>
 <%- if @before_stop %>ExecStop=-<%= @before_stop %>
 <% end -%>
-ExecStop=-/usr/bin/<%= @docker_command %> stop <%= @sanitised_title %>
+ExecStop=-/usr/bin/<%= @docker_command %> stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
 <%- if @remove_container_on_stop %>ExecStop=-/usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
 <% end -%>
 


### PR DESCRIPTION
There is a use case in our environments, where we need the dockerized app to accept SIGINT (2), so it has a chance to clean up any side-effects in it's environment. This change provides time (default: 0 seconds) for the container to shut itself down.

Note: could not find testing for docker-run*.erb (e.g. $sanitised_title), so no new testing added.