### PR TITLE
fix #466: add param for choosing install_path of docker-compose

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -13,12 +13,18 @@
 #   The version of Docker Compose to install.
 #   Defaults to the value set in $docker::params::compose_version
 #
+# [*install_path*]
+#   The path where to install Docker Compose.
+#   Defaults to the value set in $docker::params::compose_install_path
+#
 class docker::compose(
   $ensure = 'present',
-  $version = $docker::params::compose_version
+  $version = $docker::params::compose_version,
+  $install_path = $docker::params::compose_install_path
 ) inherits docker::params {
   validate_string($version)
   validate_re($ensure, '^(present|absent)$')
+  validate_absolute_path($install_path)
 
   if $ensure == 'present' {
     ensure_packages(['curl'])
@@ -26,22 +32,22 @@ class docker::compose(
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > /usr/local/bin/docker-compose-${version}",
-      creates => "/usr/local/bin/docker-compose-${version}",
+      command => "curl -s -L https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > ${install_path}/docker-compose-${version}",
+      creates => "${install_path}/docker-compose-${version}",
       require => Package['curl'],
     } ->
-    file { "/usr/local/bin/docker-compose-${version}":
+    file { "${install_path}/docker-compose-${version}":
       owner => 'root',
       mode  => '0755'
     } ->
-    file { '/usr/local/bin/docker-compose':
+    file { "${install_path}/docker-compose":
       ensure => 'link',
-      target => "/usr/local/bin/docker-compose-${version}",
+      target => "${install_path}/docker-compose-${version}",
     }
   } else {
     file { [
-      "/usr/local/bin/docker-compose-${version}",
-      '/usr/local/bin/docker-compose'
+      "${install_path}/docker-compose-${version}",
+      "${install_path}/docker-compose"
     ]:
       ensure => absent,
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,7 @@ class docker::params {
   $storage_pool_autoextend_percent   = undef
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $compose_version                   = '1.7.0'
+  $compose_install_path              = '/usr/local/bin'
 
   case $::osfamily {
     'Debian' : {


### PR DESCRIPTION
Give the possibility to choose where docker-compose is installed.