### PR TITLE
add up_args to docker-compose up cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ docker_compose { '/tmp/docker-compose.yml':
 Now when Puppet runs it will automatically run Compose is required,
 for example because the relevant Compose services aren't running.
 
-You can also pass addition options (for example to enable experimental
+You can also pass additional options (for example to enable experimental
 features) as well as provide scaling rules. The following example
 requests 2 containers be running for example. Puppet will now run
 Compose if the number of containers for a given service don't match the
@@ -453,6 +453,9 @@ docker_compose { '/tmp/docker-compose.yml':
   options => '--x-networking'
 }
 ```
+
+It is also possible to give options to the ```docker-compose up``` command
+such as ```--remove-orphans``` using the ```up_args``` option.
 
 ### Private registries
 By default images will be pushed and pulled from [index.docker.io](http://index.docker.io) unless you've specified a server. If you have your own private registry without authentication, you can fully qualify your image name. If your private registry requires authentication you may configure a registry:

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
 
   def create
     Puppet.info("Running compose project #{project}")
-    args = ['-f', name, 'up', '-d'].insert(2, resource[:options]).compact
+    args = ['-f', name, 'up', '-d'].insert(2, resource[:options]).insert(5,resource[:up_args]).compact
     dockercompose(args)
     if resource[:scale]
       instructions = resource[:scale].collect { |k,v| "#{k}=#{v}" }

--- a/lib/puppet/type/docker_compose.rb
+++ b/lib/puppet/type/docker_compose.rb
@@ -27,6 +27,13 @@ Puppet::Type.newtype(:docker_compose) do
 		end
 	end
 
+	newparam(:up_args) do
+    desc 'Arguments to be passed directly to docker-compose up.'
+		validate do |value|
+      fail 'up_args should be a String' unless value.is_a? String
+		end
+	end
+
   autorequire(:file) do
     self[:name]
   end

--- a/spec/unit/docker_compose_spec.rb
+++ b/spec/unit/docker_compose_spec.rb
@@ -10,6 +10,7 @@ describe compose do
       :provider,
       :scale,
       :options,
+      :up_args,
     ]
   end
 
@@ -33,6 +34,10 @@ describe compose do
 
 	it 'should require options to be a string' do
 		expect(compose).to require_string_for('options')
+  end
+
+	it 'should require up_args to be a string' do
+		expect(compose).to require_string_for('up_args')
   end
 
 	it 'should require scale to be a hash' do


### PR DESCRIPTION
Add an ```args``` option to be able to give options to the ```docker-compose``` command (especially ```--remove-orphans``` to the ```docker-compose up``` command).