### PR TITLE
Add configurable docker-storage-setup file path

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -399,6 +399,7 @@ class docker(
   $storage_pool_autoextend_percent   = $docker::params::storage_pool_autoextend_percent,
   $storage_config                    = $docker::params::storage_config,
   $storage_config_template           = $docker::params::storage_config_template,
+  $storage_setup_file                = $docker::params::storage_setup_file,
   $service_provider                  = $docker::params::service_provider,
   $service_config                    = $docker::params::service_config,
   $service_config_template           = $docker::params::service_config_template,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -122,6 +122,7 @@ class docker::params {
       $repo_opt = undef
       $nowarn_kernel = false
       $service_config = undef
+      $storage_setup_file = undef
 
       $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
       $package_cs_key_source = 'http://packages.docker.com/1.9/apt/gpg'
@@ -141,6 +142,7 @@ class docker::params {
     'RedHat' : {
       $service_config = '/etc/sysconfig/docker'
       $storage_config = '/etc/sysconfig/docker-storage'
+      $storage_setup_file = '/etc/sysconfig/docker-storage-setup'
       $service_hasstatus  = true
       $service_hasrestart = true
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -96,6 +96,7 @@ class docker::service (
   $storage_pool_autoextend_percent   = $docker::storage_pool_autoextend_percent,
   $storage_config                    = $docker::storage_config,
   $storage_config_template           = $docker::storage_config_template,
+  $storage_setup_file                = $docker::storage_setup_file,
   $service_provider                  = $docker::service_provider,
   $service_config                    = $docker::service_config,
   $service_config_template           = $docker::service_config_template,
@@ -133,7 +134,7 @@ class docker::service (
   }
 
   if $::osfamily == 'RedHat' {
-    file { '/etc/sysconfig/docker-storage-setup':
+    file { $storage_setup_file:
       ensure  => present,
       force   => true,
       content => template('docker/etc/sysconfig/docker-storage-setup.erb'),

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -843,6 +843,11 @@ describe 'docker', :type => :class do
         it { should contain_file(storage_setup_file).with_content(/^POOL_AUTOEXTEND_PERCENT=10/) }
       end
 
+      context 'with custom storage_setup_file' do
+        let(:params) { { 'storage_setup_file' => '/etc/sysconfig/docker-latest-storage-setup' }}
+        it { should contain_file('/etc/sysconfig/docker-latest-storage-setup').with_content(/managed by Puppet/) }
+      end
+
     end
   end
 


### PR DESCRIPTION
This fixes #538 and allows a user to specify the path for the
docker-storage-setup file.