### PR TITLE
Explicitly set variables to undef.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,7 +90,9 @@ class docker::params {
             $service_provider        = 'upstart'
             $service_hasstatus       = true
             $service_hasrestart      = false
+            $storage_config          = undef
           }
+          $service_overrides_template = undef
         }
         default: {
           $package_release = "debian-${::lsbdistcodename}"
@@ -117,6 +119,7 @@ class docker::params {
       $use_upstream_package_source = true
       $repo_opt = undef
       $nowarn_kernel = false
+      $service_config = undef
 
       $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
       $package_cs_key_source = 'http://packages.docker.com/1.9/apt/gpg'


### PR DESCRIPTION
In Puppet 4 variables should be explicitly set to avoid warnings (or errors, in the case of strict mode).

```
Puppet Unknown variable: 'docker::params::service_config'. at /etc/puppetlabs/code/environments/development/modules/docker/manifests/init.pp:360:40
Puppet Unknown variable: 'docker::params::service_overrides_template'. at /etc/puppetlabs/code/environments/development/modules/docker/manifests/init.pp:362:40
Puppet Unknown variable: 'docker::params::storage_config'. at /etc/puppetlabs/code/environments/development/modules/docker/manifests/init.pp:357:40
```

There may be more, but these are the ones I see on Ubuntu.