### PR TITLE
Fix lint and rspec test failures

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -250,7 +250,9 @@
 #   Defaults to false
 #
 # [*dm_override_udev_sync_check*]
-#   By default, the devicemapper backend attempts to synchronize with the udev device manager for the Linux kernel. This option allows disabling that synchronization, to continue even though the configuration may be buggy.
+#   By default, the devicemapper backend attempts to synchronize with the udev
+#   device manager for the Linux kernel. This option allows disabling that
+#   synchronization, to continue even though the configuration may be buggy.
 #   Defaults to true
 #
 # [*manage_package*]
@@ -401,7 +403,8 @@ class docker(
 ) inherits docker::params {
 
   validate_string($version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$', 'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
+  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
+              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
   validate_bool($manage_kernel)
   validate_bool($manage_package)
   validate_bool($docker_cs)
@@ -426,7 +429,8 @@ class docker(
   }
 
   if $log_driver {
-    validate_re($log_driver, '^(none|json-file|syslog|journald|gelf|fluentd)$', 'log_driver must be one of none, json-file, syslog, journald, gelf or fluentd')
+    validate_re($log_driver, '^(none|json-file|syslog|journald|gelf|fluentd)$',
+                'log_driver must be one of none, json-file, syslog, journald, gelf or fluentd')
   }
 
   if $selinux_enabled {
@@ -434,7 +438,8 @@ class docker(
   }
 
   if $storage_driver {
-    validate_re($storage_driver, '^(aufs|devicemapper|btrfs|overlay|vfs|zfs)$', 'Valid values for storage_driver are aufs, devicemapper, btrfs, overlay, vfs, zfs.' )
+    validate_re($storage_driver, '^(aufs|devicemapper|btrfs|overlay|vfs|zfs)$',
+                'Valid values for storage_driver are aufs, devicemapper, btrfs, overlay, vfs, zfs.' )
   }
 
   if $dm_fs {
@@ -457,7 +462,8 @@ class docker(
     fail('You need to provide both $dm_datadev and $dm_metadatadev parameters for direct lvm.')
   }
 
-  if ($dm_basesize or $dm_fs or $dm_mkfsarg or $dm_mountopt or $dm_blocksize or $dm_loopdatasize or $dm_loopmetadatasize or $dm_datadev or $dm_metadatadev) and ($storage_driver != 'devicemapper') {
+  if ($dm_basesize or $dm_fs or $dm_mkfsarg or $dm_mountopt or $dm_blocksize or $dm_loopdatasize or
+      $dm_loopmetadatasize or $dm_datadev or $dm_metadatadev) and ($storage_driver != 'devicemapper') {
     fail('Values for dm_ variables will be ignored unless storage_driver is set to devicemapper.')
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,8 @@
 class docker::install {
   $docker_command = $docker::docker_command
   validate_string($docker::version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$', 'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
+  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
+              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
   validate_string($::kernelrelease)
   validate_bool($docker::use_upstream_package_source)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,7 +125,8 @@ class docker::params {
       $package_key_source = 'http://apt.dockerproject.org/gpg'
       $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
 
-      if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+      if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
+        ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
         $detach_service_in_init = false
       } else {
         $detach_service_in_init = true

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -204,8 +204,13 @@ define docker::run(
 
     $cidfile = "/var/run/${service_prefix}${sanitised_title}.cid"
 
+    $run_with_docker_command = [
+      "${docker_command} run -d ${docker_run_flags}",
+      "--name ${sanitised_title} --cidfile=${cidfile}",
+      "--restart=\"${restart}\" ${image} ${command}",
+    ]
     exec { "run ${title} with docker":
-      command     => "${docker_command} run -d ${docker_run_flags} --name ${sanitised_title} --cidfile=${cidfile} --restart=\"${restart}\" ${image} ${command}",
+      command     => join($run_with_docker_command, ' '),
       unless      => "${docker_command} ps --no-trunc -a | grep `cat ${cidfile}`",
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
@@ -217,7 +222,8 @@ define docker::run(
       'Debian': {
         $deprecated_initscript = "/etc/init/${service_prefix}${sanitised_title}.conf"
         $hasstatus  = true
-        if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+        if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
+          ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
           $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template = 'docker/etc/systemd/system/docker-run.erb'
           $uses_systemd = true
@@ -306,8 +312,12 @@ define docker::run(
           if $initscript == "/etc/init.d/${service_prefix}${sanitised_title}" {
             # This exec sequence will ensure the old-style CID container is stopped
             # before we replace the init script with the new-style.
+            $transition_onlyif = [
+              "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid &&",
+              "/usr/bin/test -f /etc/init.d/${service_prefix}${sanitised_title}",
+            ]
             exec { "/bin/sh /etc/init.d/${service_prefix}${sanitised_title} stop":
-              onlyif  => "/usr/bin/test -f /var/run/docker-${sanitised_title}.cid && /usr/bin/test -f /etc/init.d/${service_prefix}${sanitised_title}",
+              onlyif  => join($transition_onlyif, ' '),
               require => [],
             } ->
             file { "/var/run/${service_prefix}${sanitised_title}.cid":

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -372,9 +372,9 @@ describe 'docker', :type => :class do
       end
 
       it { should compile.with_all_deps }
-      it { should contain_class('docker::repos').that_comes_before('docker::install') }
-      it { should contain_class('docker::install').that_comes_before('docker::config') }
-      it { should contain_class('docker::service').that_subscribes_to('docker::config') }
+      it { should contain_class('docker::repos').that_comes_before('Class[docker::install]') }
+      it { should contain_class('docker::install').that_comes_before('Class[docker::config]') }
+      it { should contain_class('docker::service').that_subscribes_to('Class[docker::config]') }
       it { should contain_class('docker::config') }
 
       context 'with a specific docker command' do


### PR DESCRIPTION
This fixes a bunch of warnings about long (>140 character) lines and
also fully qualifies some class references that was causing spurious
failures.