### PR TITLE
Add refresh to docker compose

### DIFF
--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -61,6 +61,17 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
     dockercompose(rm_args)
   end
 
+  def restart
+    if exists?
+      Puppet.info("Rebuilding and Restarting all containers for compose project #{project}")
+      kill_args = ['-f', name, 'kill'].insert(2, resource[:options]).compact
+      dockercompose(kill_args)
+      build_args = ['-f', name, 'build'].insert(2, resource[:options]).compact
+      dockercompose(build_args)
+      create
+    end
+  end
+
   private
   def project
     File.basename(File.dirname(name)).downcase.gsub(/[^0-9a-z ]/i, '')

--- a/lib/puppet/type/docker_compose.rb
+++ b/lib/puppet/type/docker_compose.rb
@@ -3,6 +3,10 @@ Puppet::Type.newtype(:docker_compose) do
 
   ensurable
 
+  def refresh
+      provider.restart
+  end
+
   newparam(:name) do
     desc 'Docker compose file path.'
   end


### PR DESCRIPTION
I wanted docker compose to rebuild when notified by a vcsrepo change so added this refresh method. Now:

```puppet
vcsrepo { 'repo': 
  ensure   => latest,
  ...
} ~>
docker_compose { '/repo/docker-compose.yml':
  ensure  => present,
}
```

will cause the docker compose file to be stopped, rebuilt and restarted when the repo updates. This could also be used to rebuild compose if the docker Files were being managed by docker by notifying from file change. 
