### PR TITLE
Split out beaker gems into separate group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-bundler_args: --without development
+bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 sudo: false
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -21,12 +21,15 @@ group :test do
   gem 'simplecov-console'
 end
 
+group :system_tests do
+  gem "beaker-puppet_install_helper", :require => false
+  gem "beaker-rspec"
+  gem "beaker", "~> 2.0"
+end
+
 group :development do
   gem "travis"
   gem "travis-lint"
-  gem "beaker", "~> 2.0"
-  gem "beaker-puppet_install_helper", :require => false
-  gem "beaker-rspec"
   gem "puppet-blacksmith"
   gem "guard-rake"
   gem "pry"


### PR DESCRIPTION
These gems are not required on travis, but are needed for a full CI run.