### PR TITLE
Load pry optionally

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,8 +1,12 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
-require 'pry'
 require 'beaker/puppet_install_helper'
 require 'rspec/retry'
+
+begin
+  require 'pry'
+rescue LoadError # rubocop:disable Lint/HandleExceptions for optional loading
+end
 
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 


### PR DESCRIPTION
pry is a development gem, therefore not available during acceptance testing.
Keep it in with an optional require to keep it around when debugging locally.