### PR TITLE
Allow usage of proxy for Docker Compose download

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -17,22 +17,35 @@
 #   The path where to install Docker Compose.
 #   Defaults to the value set in $docker::params::compose_install_path
 #
+# [*proxy*]
+#   Proxy to use for downloading Docker Compose.
+#
 class docker::compose(
   $ensure = 'present',
   $version = $docker::params::compose_version,
-  $install_path = $docker::params::compose_install_path
+  $install_path = $docker::params::compose_install_path,
+  $proxy = undef
 ) inherits docker::params {
   validate_string($version)
   validate_re($ensure, '^(present|absent)$')
   validate_absolute_path($install_path)
+  if $proxy != undef {
+      validate_re($proxy, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
+  }
 
   if $ensure == 'present' {
     ensure_packages(['curl'])
 
+    if $proxy != undef {
+        $proxy_opt = "--proxy ${proxy}"
+    } else {
+        $proxy_opt = ''
+    }
+
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > ${install_path}/docker-compose-${version}",
+      command => "curl -s -L ${proxy_opt} https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > ${install_path}/docker-compose-${version}",
       creates => "${install_path}/docker-compose-${version}",
       require => Package['curl'],
     } ->

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -9,7 +9,7 @@ describe 'docker::compose', :type => :class do
   context 'when no proxy is provided' do
     let(:params) { {:version => '1.7.0'} }
     it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
-           'curl -s -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+           'curl -s -L  https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
     }
   end
 

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -3,7 +3,15 @@ require 'spec_helper'
 describe 'docker::compose', :type => :class do
   it { is_expected.to compile }
 
-  let(:facts) { {:kernel => 'Linux'} }
+  let(:facts) { {
+    :osfamily                  => 'Debian',
+    :operatingsystem           => 'Ubuntu',
+    :lsbdistid                 => 'Ubuntu',
+    :lsbdistcodename           => 'maverick',
+    :kernelrelease             => '3.8.0-29-generic',
+    :operatingsystemrelease    => '10.04',
+    :operatingsystemmajrelease => '10',
+  } }
 
 
   context 'when no proxy is provided' do

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -4,6 +4,7 @@ describe 'docker::compose', :type => :class do
   it { is_expected.to compile }
 
   let(:facts) { {
+    :kernel                    => 'Linux',
     :osfamily                  => 'Debian',
     :operatingsystem           => 'Ubuntu',
     :lsbdistid                 => 'Ubuntu',

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'docker::compose', :type => :class do
+  it { is_expected.to compile }
+
+  let(:facts) { {:kernel => 'Linux'} }
+
+
+  context 'when no proxy is provided' do
+    let(:params) { {:version => '1.7.0'} }
+    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
+           'curl -s -L https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    }
+  end
+
+  context 'when proxy is provided' do
+    let(:params) { {:proxy => 'http://proxy.example.org:3128/',
+                    :version => '1.7.0'} }
+    it { is_expected.to compile }
+    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
+           'curl -s -L --proxy http://proxy.example.org:3128/ https://github.com/docker/compose/releases/download/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    }
+  end
+
+  context 'when proxy is not a http proxy' do
+    let(:params)  { {:proxy => 'this is not a URL'} }
+    it do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/does not match/)
+    end
+  end
+
+end


### PR DESCRIPTION
This PR enables to use a proxy for downloading Docker Compose. Sometimes the server in which the Puppet code runs is behind a proxy and can't access the download target directly, but it is not required to specify a proxy for the whole system. In such cases it can be helpful to specify the proxy for this download only.

Currently the tests with _PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes_ fail (see https://travis-ci.org/mikey179/garethr-docker/builds/145836854) - I'm a bit unsure what to do about it. From what I see I'd need to specify all variables from _manifests/params.pp_ in the `let(:facts)` section, but is this really the way it should be done?
