### PR TITLE
fix #559: add param for restarting containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,10 +447,15 @@ docker_compose { '/tmp/docker-compose.yml':
 Now when Puppet runs it will automatically run Compose is required,
 for example because the relevant Compose services aren't running.
 
+If a refresh event happens, all the containers are restarted 
+by default. It is possible to avoid this behavior using the ```restart```
+argument (```false``` to simply run the ```up``` command, ```true``` for
+restarting all containers, default: ```true```).
+
 You can also pass additional options (for example to enable experimental
 features) as well as provide scaling rules. The following example
 requests 2 containers be running for example. Puppet will now run
-Compose if the number of containers for a given service don't match the
+Compose if the number of containers for a given service doesn't match the
 provided scale values.
 
 ```puppet
@@ -459,6 +464,7 @@ docker_compose { '/tmp/docker-compose.yml':
   scale   => {
     'compose_test' => 2,
   },
+  restart => true,
   options => '--x-networking'
 }
 ```

--- a/lib/puppet/provider/docker_compose/ruby.rb
+++ b/lib/puppet/provider/docker_compose/ruby.rb
@@ -63,9 +63,12 @@ Puppet::Type.type(:docker_compose).provide(:ruby) do
 
   def restart
     if exists?
-      Puppet.info("Rebuilding and Restarting all containers for compose project #{project}")
-      kill_args = ['-f', name, 'kill'].insert(2, resource[:options]).compact
-      dockercompose(kill_args)
+      if resource[:restart] != false
+        Puppet.info("Restarting all containers for compose project #{project}")
+        kill_args = ['-f', name, 'kill'].insert(2, resource[:options]).compact
+        dockercompose(kill_args)
+      end
+      Puppet.info("Rebuilding all containers for compose project #{project}")
       build_args = ['-f', name, 'build'].insert(2, resource[:options]).compact
       dockercompose(build_args)
       create

--- a/lib/puppet/type/docker_compose.rb
+++ b/lib/puppet/type/docker_compose.rb
@@ -4,7 +4,7 @@ Puppet::Type.newtype(:docker_compose) do
   ensurable
 
   def refresh
-      provider.restart
+    provider.restart
   end
 
   newparam(:name) do
@@ -13,30 +13,37 @@ Puppet::Type.newtype(:docker_compose) do
 
   newparam(:scale) do
     desc 'A hash of compose services and number of containers.'
- 		validate do |value|
+    validate do |value|
       fail 'scale should be a Hash' unless value.is_a? Hash
-			unless value.all? { |k,v| k.is_a? String }
+      unless value.all? { |k,v| k.is_a? String }
         fail 'The name of the compose service in scale should be a String'
-			end
-			unless value.all? { |k,v| v.is_a? Integer }
+      end
+      unless value.all? { |k,v| v.is_a? Integer }
         fail 'The number of containers in scale should be an Integer'
-			end
-		end
-   end
+      end
+    end
+  end
 
-	newparam(:options) do
+  newparam(:options) do
     desc 'Additional options to be passed directly to docker-compose.'
-		validate do |value|
+    validate do |value|
       fail 'options should be a String' unless value.is_a? String
-		end
-	end
+    end
+  end
 
-	newparam(:up_args) do
+  newparam(:up_args) do
     desc 'Arguments to be passed directly to docker-compose up.'
-		validate do |value|
+    validate do |value|
       fail 'up_args should be a String' unless value.is_a? String
-		end
-	end
+    end
+  end
+
+  newparam(:restart) do
+    desc 'Argument to set if containers have to be killed and restarted on refresh event'
+    validate do |value|
+      fail 'restart should be a Boolean' unless value.is_a? TrueClass or value.is_a? FalseClass
+    end
+  end
 
   autorequire(:file) do
     self[:name]

--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -46,6 +46,10 @@ define docker::registry(
       $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     }
+    elsif $username != undef and $password != undef {
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" ${server}"
+      $auth_environment = "password=${password}"
+    }
     else {
       $auth_cmd = "${docker_command} login ${server}"
       $auth_environment = undef

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,3 +25,16 @@ RSpec::Matchers.define :require_hash_for do |property|
     "#{type_class} should require #{property} to be a Hash"
   end
 end
+
+RSpec::Matchers.define :require_boolean_for do |property|
+  match do |type_class|
+    config = {:name => 'name'}
+    config[property] = 2
+    expect do
+      type_class.new(config)
+    end.to raise_error(Puppet::Error, /#{property} should be a Boolean/)
+  end
+  failure_message do |type_class|
+    "#{type_class} should require #{property} to be a Boolean"
+  end
+end

--- a/spec/unit/docker_compose_spec.rb
+++ b/spec/unit/docker_compose_spec.rb
@@ -11,6 +11,7 @@ describe compose do
       :scale,
       :options,
       :up_args,
+      :restart,
     ]
   end
 
@@ -38,6 +39,10 @@ describe compose do
 
 	it 'should require up_args to be a string' do
 		expect(compose).to require_string_for('up_args')
+  end
+
+	it 'should require restart to be a boolean' do
+		expect(compose).to require_boolean_for('restart')
   end
 
 	it 'should require scale to be a hash' do

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -3,7 +3,7 @@ EnvironmentFile=-/etc/sysconfig/docker
 EnvironmentFile=-/etc/sysconfig/docker-storage
 EnvironmentFile=-/etc/sysconfig/docker-network
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_command %>d $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
Add a parameter to select if a refresh event must restart all containers or simply run the `docker-compose up` command.
