### PR TITLE
add initial support for sles 12.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -415,8 +415,8 @@ class docker(
 ) inherits docker::params {
 
   validate_string($version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
-              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
+  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo|Suse)$',
+              'This module only works on Debian or Red Hat based systems or on Archlinux, on Gentoo and Suse.')
   validate_bool($manage_kernel)
   validate_bool($manage_package)
   validate_bool($docker_cs)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,8 +7,8 @@
 class docker::install {
   $docker_command = $docker::docker_command
   validate_string($docker::version)
-  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo)$',
-              'This module only works on Debian or Red Hat based systems or on Archlinux as on Gentoo.')
+  validate_re($::osfamily, '^(Debian|RedHat|Archlinux|Gentoo|Suse)$',
+              'This module only works on Debian or Red Hat based systems or on Archlinux on Gentoo and Suse.')
   validate_bool($docker::use_upstream_package_source)
 
   if $docker::version and $docker::ensure != 'absent' {
@@ -59,6 +59,12 @@ class docker::install {
     'Gentoo': {
       $manage_kernel = false
     }
+    'Suse': {
+      if versioncmp($::operatingsystemrelease, '12.0') < 0 {
+        fail('Docker needs Suse version to be at least 12.0.')
+      }
+      $manage_kernel = false
+    }
     default: {}
   }
 
@@ -89,6 +95,9 @@ class docker::install {
         }
         'Gentoo' : {
           $pk_provider = 'portage'
+        }
+        'Suse': {
+          $pk_provider = 'zypper'
         }
         default : {
           $pk_provider = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -281,6 +281,30 @@ class docker::params {
       $storage_config = undef
       $storage_setup_file = undef
     }
+    'Suse':{
+      $manage_epel = false
+      $docker_group = $docker_group_default
+      $package_key_source = undef
+      $package_source_location = undef
+      $package_key = undef
+      $package_repos = undef
+      $package_release = undef
+      $use_upstream_package_source = false
+      $package_name = 'docker'
+      $service_name = $service_name_default
+      $docker_command = $docker_command_default
+      $detach_service_in_init = false
+      $repo_opt = undef
+      $nowarn_kernel = false
+      $service_provider   = 'systemd'
+      $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-suse.conf.erb'
+      $service_hasstatus  = true
+      $service_hasrestart = true
+      $service_config_template = 'docker/etc/sysconfig/docker.systemd.erb'
+      $service_config = '/etc/sysconfig/docker'
+      $storage_config = '/etc/sysconfig/docker-storage'
+      $storage_setup_file = '/etc/sysconfig/docker-storage-setup'
+    }
     default: {
       $manage_epel = false
       $docker_group = $docker_group_default

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -272,8 +272,16 @@ define docker::run(
         $mode           = '0775'
         $uses_systemd   = false
       }
+      'Suse':{
+          $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
+          $init_template  = 'docker/etc/systemd/system/docker-run.erb'
+          $hasstatus      = true
+          $mode           = '0644'
+          $uses_systemd   = true
+
+        }
       default: {
-        fail('Docker needs a Debian, RedHat, Archlinux or Gentoo based system.')
+        fail('Docker needs a Debian, RedHat, Archlinux, Gentoo or Suse based system.')
       }
     }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -111,8 +111,8 @@ class docker::service (
   $tls_key                           = $docker::tls_key,
 ) {
 
-  unless $::osfamily =~ /(Debian|RedHat|Archlinux|Gentoo)/ {
-    fail('The docker::service class needs a Debian, RedHat, Archlinux or Gentoo based system.')
+  unless $::osfamily =~ /(Debian|RedHat|Archlinux|Gentoo|Suse)/ {
+    fail('The docker::service class needs a Debian, RedHat, Archlinux, Gentoo or Suse based system.')
   }
 
   $dns_array = any2array($dns)

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,12 @@
       "operatingsystemrelease": [
         "21"
       ]
+    },
+    {
+      "operatingsystem": "Suse",
+      "operatingsystemrelease": [
+        "12"
+      ]
     }
   ],
   "requirements": [

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-suse.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-suse.conf.erb
@@ -1,0 +1,10 @@
+[Service]
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+ExecStart=
+ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+      $DOCKER_STORAGE_OPTIONS \
+      $DOCKER_NETWORK_OPTIONS \
+      $BLOCK_REGISTRY \
+      $INSECURE_REGISTRY


### PR DESCRIPTION
Hi,

I added support for Sles 12.0 running with systemd. 
The module is tested (installation, image pull and docker run) and is currently used in our organization.

Docker-compose is currently untested, because the default version in sles 12 is atm broken. 
Networks is untested, we used defaults.
Registry is untested, but shouldn't pose any problems, as it is os unspecific.
Repos is not used, as docker is already in Sles default repositories and is activated by default (our installation, not 100% sure, might need to add support later).
system_user is untested.

Please inform me if you think something needs improvement.

Kind regards, 
Alex