### PR TITLE
Add ability to configure package pinning on Debian based systems.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,6 +156,20 @@
 #   If you run your own package mirror, you may set this
 #   to false.
 #
+# [*pin_upstream_package_source*]
+#   Pin upstream package source; this option currently only has any effect on
+#   apt-based distributions.  Set to false to remove pinning on the upstream
+#   package repository.  See also "apt_source_pin_level".
+#   Defaults to true
+#
+# [*apt_source_pin_level*]
+#   What level to pin our source package repository to; this only is relevent
+#   if you're on an apt-based system (Debian, Ubuntu, etc) and
+#   $use_upstream_package_source is set to true.  Set this to false to disable
+#   pinning, and undef to ensure the apt preferences file apt::source uses to
+#   define pins is removed.
+#   Defaults to 10
+#
 # [*package_source_location*]
 #   If you're using an upstream package source, what is it's
 #   location. Defaults to http://get.docker.com/ubuntu on Debian
@@ -348,6 +362,8 @@ class docker(
   $log_opt                           = $docker::params::log_opt,
   $selinux_enabled                   = $docker::params::selinux_enabled,
   $use_upstream_package_source       = $docker::params::use_upstream_package_source,
+  $pin_upstream_package_source       = $docker::params::pin_upstream_package_source,
+  $apt_source_pin_level              = $docker::params::apt_source_pin_level,
   $package_source_location           = $docker::params::package_source_location,
   $package_release                   = $docker::params::package_release,
   $package_repos                     = $docker::params::package_repos,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,6 +125,8 @@ class docker::params {
       $docker_group = $docker_group_default
       $package_repos = 'main'
       $use_upstream_package_source = true
+      $pin_upstream_package_source = true
+      $apt_source_pin_level = 10
       $repo_opt = undef
       $nowarn_kernel = false
       $service_config = undef

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -24,8 +24,18 @@ class docker::repos {
           key               => $package_key,
           key_source        => $key_source,
           required_packages => 'debian-keyring debian-archive-keyring',
-          pin               => '10',
           include_src       => false,
+        }
+        $url_split = split($location, '/')
+        $repo_host = $url_split[2]
+        $pin_ensure = $docker::pin_upstream_package_source ? {
+            true    => 'present',
+            default => 'absent',
+        }
+        apt::pin { 'docker':
+          ensure   => $pin_ensure,
+          origin   => $repo_host,
+          priority => $docker::apt_source_pin_level,
         }
         if $docker::manage_package {
           include apt

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -50,6 +50,7 @@ describe 'docker', :type => :class do
         it { should contain_class('apt') }
         it { should contain_package('docker').with_name('docker-engine').with_ensure('present') }
         it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo') }
+        it { should contain_apt__pin('docker').with_origin('apt.dockerproject.org') }
         it { should contain_package('docker').with_install_options(nil) }
 
         it { should contain_file('/etc/default/docker').without_content(/icc=/) }
@@ -62,14 +63,29 @@ describe 'docker', :type => :class do
         context 'with no upstream package source' do
           let(:params) { {'use_upstream_package_source' => false } }
           it { should_not contain_apt__source('docker') }
+          it { should_not contain_apt__pin('docker') }
           it { should contain_package('docker').with_name('docker-engine') }
         end
 
         context 'with no upstream package source' do
           let(:params) { {'use_upstream_package_source' => false } }
           it { should_not contain_apt__source('docker') }
+          it { should_not contain_apt__pin('docker') }
           it { should_not contain_class('epel') }
           it { should contain_package('docker') }
+        end
+
+        context 'with no package pinning' do
+          let(:params) { {'pin_upstream_package_source' => false } }
+          it { should contain_apt__pin('docker').with_ensure('absent') }
+        end
+
+        context 'with different package pinning priority' do
+          let(:params) { {
+            'pin_upstream_package_source' => true,
+            'apt_source_pin_level'        => 900,
+          } }
+          it { should contain_apt__pin('docker').with_priority(900) }
         end
 
         context 'when given a specific tmp_dir' do
@@ -737,6 +753,7 @@ describe 'docker', :type => :class do
     context 'with no upstream package source' do
       let(:params) { {'use_upstream_package_source' => false } }
       it { should_not contain_apt__source('docker') }
+      it { should_not contain_apt__pin('docker') }
       it { should contain_package('docker').with_name('docker-engine') }
     end
   end


### PR DESCRIPTION
An updated version of PR #86.

Allows us to reconfigure the apt pinning of the docker repo so that we can upgrade docker-engine.
