### PR TITLE
allow registry login without email

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -46,6 +46,10 @@ define docker::registry(
       $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" -e '${email}' ${server}"
       $auth_environment = "password=${password}"
     }
+    elsif $username != undef and $password != undef {
+      $auth_cmd = "${docker_command} login -u '${username}' -p \"\${password}\" ${server}"
+      $auth_environment = "password=${password}"
+    }
     else {
       $auth_cmd = "${docker_command} login ${server}"
       $auth_environment = undef


### PR DESCRIPTION
Since docker 1.13 the email option on login is deprecated. Relates to issue #588 
