### PR TITLE
Add the memory cgroup to Grub on Debian systems

### DIFF
--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -1,0 +1,14 @@
+# == Class: docker::grub
+#
+# For systems that need grub modififications
+class docker::grub {
+  file_line { 'memory_cgroup':
+    path => '/etc/default/grub',
+    line => 'GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT} cgroup_enable=memory"'
+  } ~>
+  exec { 'rebuild-grub':
+    path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+    command     => 'update-grub2',
+    refreshonly => true,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -359,6 +359,7 @@ class docker(
   $root_dir                          = $docker::params::root_dir,
   $tmp_dir                           = $docker::params::tmp_dir,
   $manage_kernel                     = $docker::params::manage_kernel,
+  $manage_memory_cgroup              = $docker::params::manage_memory_cgroup,
   $dns                               = $docker::params::dns,
   $dns_search                        = $docker::params::dns_search,
   $socket_group                      = $docker::params::socket_group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -36,6 +36,7 @@ class docker::install {
         # Debian does not need extra kernel packages
         $manage_kernel = false
       }
+      $mange_memory_cgroup = $docker::manage_memory_cgroup
     }
     'RedHat': {
       if $::operatingsystem == 'Amazon' {
@@ -108,5 +109,8 @@ class docker::install {
         name   => $docker::package_name,
       }))
     }
+  }
+  if $docker::manage_memory_cgroup {
+    class {'::docker::grub': }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -143,6 +143,7 @@ class docker::params {
       } else {
         $detach_service_in_init = true
       }
+      $manage_memory_cgroup = true
 
     }
     'RedHat' : {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -739,6 +739,7 @@ describe 'docker', :type => :class do
       it { should_not contain_apt__source('docker') }
       it { should contain_package('docker').with_name('docker-engine') }
     end
+    it { should contain_file('/etc/default/grub').with_content(/cgroup_enable=memory/)}
   end
 
   context 'specific to RedHat' do


### PR DESCRIPTION
Added support the option to enable memory cgroup support on Debian (enabled by default) along with an rspec test. Sorry, beaker is beyond me at the moment as I have (to my shame) only just started learning it. All I am doing is adding a line to `/etc/default/grub` and launching `update-grub`.

There is one problem: as it makes modifications to grub, it requires a reboot. Not sure how to work around this at present. Better minds than me please chime in.

As far as I know, this is only necessary on Debian itself, not Ubuntu. 