### PR TITLE
Fix deprecated apt::source parameters

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -17,15 +17,21 @@ class docker::repos {
           $key_source = $docker::package_key_source
           $package_key = $docker::package_key
         }
+        $apt_required_packages = [ 'debian-keyring', 'debian-archive-keyring', ]
+        ensure_packages($apt_required_packages)
         apt::source { 'docker':
-          location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
-          required_packages => 'debian-keyring debian-archive-keyring',
-          pin               => '10',
-          include_src       => false,
+          location => $location,
+          release  => $docker::package_release,
+          repos    => $docker::package_repos,
+          key      => {
+            'id'     => $package_key,
+            'source' => $key_source,
+          },
+          pin      => '10',
+          include  => {
+            'src' => false,
+          },
+          require  => Package[$apt_required_packages],
         }
         if $docker::manage_package {
           include apt

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/garethr/garethr-docker/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <= 3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 2.0.0 <= 3.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 0.0.6"}
   ],
   "data_provider": null,


### PR DESCRIPTION
`puppetlabs/apt` 2.0.0 has been release well over a year ago and deprecated some parameters for `apt::source` (see [Changelog](https://forge.puppet.com/puppetlabs/apt/changelog#aptsource)).

In `puppetlabs/apt` version 2.0.0 these parameters (`key_source`, `include_src`, ...) have been completely removed, in version >= 2.1.0 using these results in a deprecation warning.

Isn't it time to finally implement these changes and require `puppetlabs/apt` >= 2.0.0? ;-)
