### PR TITLE
Systemd restart policy

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -15,6 +15,11 @@
 #
 #    extra_parameters => ['--restart=always']
 #
+# However, if your system is using sytemd this restart policy will be
+# ineffective because the ExecStop commands will run which will cause
+# docker to stop restarting it.  In this case you should use the
+# systemd_restart option to specify the policy you want.
+#
 # This will allow the docker container to be restarted if it dies, without
 # puppet help.
 #
@@ -47,6 +52,12 @@
 # An array of additional command line arguments to pass to the `docker run`
 # command. Useful for adding additional new or experimental options that the
 # module does not yet support.
+#
+# [*systemd_restart*]
+# (optional) If the container is to be managed by a systemd unit file set the
+# Restart option on the unit file.  Can be any valid value for this systemd
+# configuration.  Most commonly used are on-failure or always.
+# Default: on-failure
 #
 define docker::run(
   $image,

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -79,6 +79,7 @@ define docker::run(
   $privileged = false,
   $detach = undef,
   $extra_parameters = undef,
+  $systemd_restart = 'on-failure',
   $extra_systemd_parameters = {},
   $pull_on_start = false,
   $after = [],
@@ -154,6 +155,9 @@ define docker::run(
   }
 
   validate_hash($extra_systemd_parameters)
+  if $systemd_restart {
+    validate_re($systemd_restart, '^(no|always|on-success|on-failure|on-abnormal|on-abort|on-watchdog)$')
+  }
 
   if $detach == undef {
     $valid_detach = $docker::params::detach_service_in_init

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -18,7 +18,7 @@ Wants=<%= @wants.uniq.join(" ") %>
 Requires=<%= @requires.uniq.join(" ") %>
 
 [Service]
-Restart=on-failure
+Restart=<%= @systemd_restart %>
 StartLimitInterval=20
 StartLimitBurst=5
 TimeoutStartSec=0


### PR DESCRIPTION
If on an systemd system and using the init style docker restart policies are not effective.  This is because as soon as the container stops for any reason systemd will see it exit and systemd executes the ExecStop commands which will cause docker to stop enforcing the restart policy.  Due to this behavior between the two it is not possible to use Docker restart policies with systemd.

Fortunately, systemd has it's own restart policies.  But current this is hardcoded in the template to on-failure.  So if you wanted the equivalent of the docker --restart=always in systemd you can't do it right now.

This pull request adds a new systemd_restart option that allows you to specify the systemd restart policy.  It defaults to on-failure so that the change has no impact on existing users.
