### PR TITLE
allow docker group to be overridden

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -289,6 +289,10 @@
 #   Specify an array of users to add to the docker group
 #   Default is empty
 #
+# [*docker_group*]
+#   Specify a string for the docker group
+#   Default is OS and package specific
+#
 # [*repo_opt*]
 #   Specify a string to pass as repository options (RedHat only)
 #
@@ -391,6 +395,7 @@ class docker(
   $docker_command                    = $docker::params::docker_command,
   $daemon_subcommand                 = $docker::params::daemon_subcommand,
   $docker_users                      = [],
+  $docker_group                      = $docker::params::docker_group,
   $repo_opt                          = $docker::params::repo_opt,
   $nowarn_kernel                     = $docker::params::nowarn_kernel,
   $storage_devs                      = $docker::params::storage_devs,

--- a/manifests/system_user.pp
+++ b/manifests/system_user.pp
@@ -9,7 +9,8 @@
 define docker::system_user (
   $create_user = true) {
 
-  include docker::params
+  include docker
+  $docker_group = $docker::docker_group
 
   if $create_user {
     ensure_resource('user', $name, {'ensure' => 'present' })
@@ -17,7 +18,7 @@ define docker::system_user (
   }
 
   exec { "docker-system-user-${name}":
-    command => "/usr/sbin/usermod -aG ${docker::params::docker_group} ${name}",
-    unless  => "/bin/cat /etc/group | grep '^${docker::params::docker_group}:' | grep -qw ${name}",
+    command => "/usr/sbin/usermod -aG ${docker_group} ${name}",
+    unless  => "/bin/cat /etc/group | grep '^${docker_group}:' | grep -qw ${name}",
   }
 }


### PR DESCRIPTION
This is really a workaround, but I'm not sure how I'd even tackle handling the params.pp logic without potentially impacting others.

I'm trying to use the RHEL7 stock docker, which uses group _dockerroot_. Unfortunately [this params block](https://github.com/garethr/garethr-docker/blob/v5.3.0/manifests/params.pp#L173-L177) negates the logic in [this params block](https://github.com/garethr/garethr-docker/blob/v5.3.0/manifests/params.pp#L201-L204) forcing RHEL7 to always use the `default_docker_group` of _docker_.

I don't really know how to fix the non-intuitive use of the same variable name in params and init, where logic exists for it in params but users can only override it later in the processing path through init.

I'm open to other suggestions on how to fix this problem, but for now this is broken for my use case.