### PR TITLE
Fixed for https://github.com/garethr/garethr-docker/issues/511

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -51,6 +51,8 @@ ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
 ExecStop=-/usr/bin/<%= @docker_command %> stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>
 <%- if @remove_container_on_stop %>ExecStop=-/usr/bin/<%= @docker_command %> rm <% if @remove_volume_on_stop %>-v<% end %> <%= @sanitised_title %>
 <% end -%>
+<%- if @detach %>RemainAfterExit=true
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a implementation of fix suggested in https://github.com/garethr/garethr-docker/issues/511 

I can confirm the service remains in Active: active (exited) state and isn't killed and restarted by systemd as per the previous behaviour when detach=true is set.

Feel free to comment with suggestions for improvement, I will implement.