### PR TITLE
Prevent exceeding systemd line length limit

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -50,7 +50,7 @@ module Puppet::Parser::Functions
 
     multi_flags = lambda { |values, format|
       filtered = [values].flatten.compact
-      filtered.map { |val| sprintf(format, val) }
+      filtered.map { |val| sprintf(format + " \\\n", val) }
     }
 
     [

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -287,7 +287,7 @@ require 'spec_helper'
 
       context 'when passing a links option' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'links' => ['example:one', 'example:two']} }
-        it { should contain_file(initscript).with_content(/ --link example:one --link example:two /) }
+        it { should contain_file(initscript).with_content(/--link example:one/).with_content(/--link example:two/) }
       end
 
       context 'when passing a hostname' do


### PR DESCRIPTION
systemd has a line length limit of 2048 characters.
https://bugs.freedesktop.org/show_bug.cgi?id=85308

We recently stumbled across this problem when running a container that accepted a lot of configuration by environment variables.

This simply adds a new line break after every parameter.