### PR TITLE
Avoid conflicts with an already declared curl package

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -27,7 +27,9 @@ class docker::compose(
   validate_absolute_path($install_path)
 
   if $ensure == 'present' {
-    ensure_packages(['curl'])
+    if !defined (Package['curl']) {
+      ensure_packages(['curl'])
+    }
 
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',


### PR DESCRIPTION
Curl is a very common package that will be most likely declared by custom modules too. This PR avoids conflicts with a curl package already declared by other modules (most likely custom modules).