### PR TITLE
Set RestartSec to 5 for systemd service

### DIFF
--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -22,6 +22,7 @@ Restart=<%= @systemd_restart %>
 StartLimitInterval=20
 StartLimitBurst=5
 TimeoutStartSec=0
+RestartSec=5
 Environment="HOME=/root"
 <%- if @_syslog_identifier -%>
 SyslogIdentifier=<%= @_syslog_identifier %>


### PR DESCRIPTION
This avoids hitting the StartLimitBurst and StartLimitInterval limits in case starting a docker container fails immediately because the dependent containers are not available yet.