### PR TITLE
Stop hiding failed image builds

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -124,7 +124,7 @@ define docker::image(
       environment => 'HOME=/root',
       path        => ['/bin', '/usr/bin'],
       timeout     => 0,
-      returns     => ['0', '1'],
+      returns     => ['0', '2'],
       require     => File['/usr/local/bin/update_docker_image.sh'],
     }
   }

--- a/templates/update_docker_image.sh.erb
+++ b/templates/update_docker_image.sh.erb
@@ -2,7 +2,7 @@
 #
 # Pulls a docker image.
 # Returns 0 if there a change.
-# Returns 1 if there is no change.
+# Returns 2 if there is no change.
 # Returns 3 if something when wrong.
 #
 DOCKER_IMAGE=$1
@@ -16,7 +16,7 @@ if [[ -z $AFTER ]]; then
   exit 3
 elif [[ $BEFORE == $AFTER ]]; then
   echo "No updates to ${DOCKER_IMAGE} available. Currently on ${AFTER}."
-  exit 1
+  exit 2
 else
   echo "${DOCKER_IMAGE} updated. Changed from ${BEFORE} to ${AFTER}."
   exit 0


### PR DESCRIPTION
With the previous code, a failing image build is marked success by puppet. 

This change removes '1' as a valid exit code so that failed image builds will be correctly be marked as "Error". Since '0' is the default, there is no need for the "returns" parameter.