### PR TITLE
Limit Image -> Run dependencies to those used

### DIFF
--- a/manifests/image.pp
+++ b/manifests/image.pp
@@ -129,4 +129,5 @@ define docker::image(
     }
   }
 
+  Docker::Image <| title == $title |> -> Docker::Run <| image == $image_arg |>
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -527,7 +527,7 @@ class docker(
   contain 'docker::config'
   contain 'docker::service'
 
-  Class['docker'] -> Docker::Registry <||> -> Docker::Image <||> -> Docker::Run <||>
-  Class['docker'] -> Docker::Image <||> -> Docker::Run <||>
+  Class['docker'] -> Docker::Registry <||> -> Docker::Image <||>
+  Class['docker'] -> Docker::Image <||>
   Class['docker'] -> Docker::Run <||>
 }

--- a/spec/acceptance/docker_full_spec.rb
+++ b/spec/acceptance/docker_full_spec.rb
@@ -541,6 +541,32 @@ describe 'the Puppet Docker module' do
 
         shell('docker inspect container-3-6', :acceptable_exit_codes => [1])
       end
+
+      it 'should allow dependency for ordering of independent run and image' do
+        pp=<<-EOS
+          class { 'docker':}
+
+          docker::image { 'ubuntu': }
+
+          docker::run { 'container_3_7_1':
+            image   => 'ubuntu',
+            command => 'init',
+          }
+
+          docker::image { 'busybox':
+            require => Docker::Run['container_3_7_1'],
+          }
+
+          docker::run { 'container_3_7_2':
+            image   => 'busybox',
+            command => 'init',
+          }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes => true) unless fact('selinux') == 'true'
+
+      end
     end
 
     describe "docker::exec" do


### PR DESCRIPTION
Use searching in the resource collection to limit adding dependencies on
Docker::Image for only those Docker::Run resources defined to use the
specific image.

This reduces the likelihood of accidental cyclical dependencies where
consumers defined a manifest per service containing an image and run,
and then try to add a dependency from one service class onto another.

Fixes #640