### PR TITLE
adding swarm mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,40 @@ docker_compose { '/tmp/docker-compose.yml':
 It is also possible to give options to the ```docker-compose up``` command
 such as ```--remove-orphans``` using the ```up_args``` option.
 
+### Swarm mode
+Docker Engine 1.12 includes swarm mode for natively managing a cluster of Docker Engines called a swarm. You can now cluster your Docker engines with the one of the following Puppet resources.
+For a swarm manager:
+
+```puppet
+docker::swarm {'cluster_manager':
+  init           => true,
+  advertise_addr => '192.168.1.1',
+  listen_addr    => '192.168.1.1,  
+} 
+```
+In the above example we have configured a swarm manager with ```init => true``` then set the ```advertise_addr``` and ```listen_addr```. Both the ```advertise_addr``` and ```listen_addr``` are set for the cluster communications between nodes. Please note the ```advertise_addr``` and ```listen_addr``` must be set for a multihomed server. For more advance flags to configure raft snapshots etc please read the readme at the top of the ```docker::swarm``` class.  
+
+For a swarm worker:
+```puppet
+docker::swarm {'cluster_worker':
+join           => true,
+advertise_addr => '192.168.1.2',
+listen_addr    => '192.168.1.2,
+manager_ip     => '192.168.1.1',
+token          => 'SWMTKN-1-2lw8bnr57qsu74d6iq2q1wr2wq2i334g7425dfr3zucimvh4bl-2vwn6gysbdj605l37c61iixie'
+} 
+```
+
+In this example we have joined a node to the cluster using ```join => true```. For a worker node or second manager you need to pass a current managers ip address ```manager_ip => '192.168.1.1'```
+The other important configuration is the token you pass to the manager. The token will define the nodes role in the cluster, as there will be a token to create another manager and a different token for the worker nodes.
+
+To remove a node from a cluster use the following:
+```puppet
+docker::swarm {'cluster_worker':
+ensure => absent
+}
+```
+
 ### Private registries
 By default images will be pushed and pulled from [index.docker.io](https://index.docker.io) unless you've specified a server. If you have your own private registry without authentication, you can fully qualify your image name. If your private registry requires authentication you may configure a registry:
 

--- a/lib/puppet/parser/functions/docker_swarm_init_flags.rb
+++ b/lib/puppet/parser/functions/docker_swarm_init_flags.rb
@@ -1,0 +1,51 @@
+require 'shellwords'
+
+module Puppet::Parser::Functions
+  # Transforms a hash into a string of docker swarm init flags
+  newfunction(:docker_swarm_init_flags, :type => :rvalue) do |args|
+    opts = args[0] || {}
+    flags = []
+
+    if opts['init'].to_s != 'false'
+      flags << 'init'
+    end
+
+    if opts['advertise_addr'].to_s != 'undef'
+      flags << "--advertise-addr '#{opts['advertise_addr']}'"
+    end
+    
+    if opts['autolock'].to_s != 'false'
+      flags << '--autolock'
+    end
+    
+    if opts['cert_expiry'].to_s != 'undef'
+      flags << "--cert-expiry '#{opts['cert_expiry']}'"
+    end
+   
+    if opts['dispatcher_heartbeat'].to_s != 'undef'
+      flags << "--dispatcher-heartbeat '#{opts['dispatcher_heartbeat']}'"
+    end  
+     
+    if opts['external_ca'].to_s != 'undef'
+      flags << "--external-ca '#{opts['external_ca']}'"	    
+    end
+
+    if opts['force_new_cluster'].to_s != 'false'
+      flags << '--force-new-cluster'
+    end
+    
+    if opts['listen_addr'].to_s != 'undef'
+      flags << "--listen-addr '#{opts['listen_addr']}'"
+    end
+
+    if opts['max_snapshots'].to_s != 'undef'
+      flags << "--max-snapshots '#{opts['max_snapshots']}'"
+    end     
+    
+    if opts['snapshot_interval'].to_s != 'undef'
+      flags << "--snapshot-interval '#{opts['snapshot_interval']}'"
+    end 
+
+    flags.flatten.join(" ")
+  end
+end

--- a/lib/puppet/parser/functions/docker_swarm_join_flags.rb
+++ b/lib/puppet/parser/functions/docker_swarm_join_flags.rb
@@ -1,0 +1,27 @@
+require 'shellwords'
+
+module Puppet::Parser::Functions
+  # Transforms a hash into a string of docker swarm init flags
+  newfunction(:docker_swarm_join_flags, :type => :rvalue) do |args|
+    opts = args[0] || {}
+    flags = []
+
+    if opts['join'].to_s != 'false'
+      flags << 'join'
+    end
+
+    if opts['advertise_addr'].to_s != 'undef'
+      flags << "--advertise-addr '#{opts['advertise_addr']}'"
+    end
+     
+    if opts['listen_addr'].to_s != 'undef'
+      flags << "--listen-addr '#{opts['listen_addr']}'"
+    end
+    
+    if opts['token'].to_s != 'undef'
+      flags << "--token '#{opts['token']}'"
+    end
+
+    flags.flatten.join(" ")
+  end
+end

--- a/manifests/swarm.pp
+++ b/manifests/swarm.pp
@@ -1,0 +1,162 @@
+# == Define: docker::swarm
+# 
+# A define that managers a Docker Swarm Mode cluster
+#
+# == Paramaters
+#
+# [*ensure*] 
+#  This ensures that the cluster is present or not.
+#  Defaults to present
+#  Note this forcefully removes a node from the cluster. Make sure all worker nodes
+#  have been removed before managers
+#
+# [*init*]
+#  This creates the first worker node for a new cluster.
+#  Set init to true to create a new cluster
+#  Defaults to false  
+#
+# [*join*]
+#  This adds either a worker or manger node to the cluster.
+#  The role of the node is defined by the join token.
+#  Set to true to join the cluster
+#  Defaults to false
+#
+# [*advertise_addr*]
+#  The address that your node will advertise to the cluster for raft.
+#  On multihomed servers this flag must be passed
+#  Defaults to undef
+#
+# [*autolock*]
+#   Enable manager autolocking (requiring an unlock key to start a stopped manager)
+#   Defaults to undef
+#
+# [*cert_expiry*]
+#  Validity period for node certificates (ns|us|ms|s|m|h) (default 2160h0m0s)
+#  defaults to undef
+#  
+# [*dispatcher_heartbeat*]
+#  Dispatcher heartbeat period (ns|us|ms|s|m|h) (default 5s)
+#  Defaults to undef
+#
+# [*external_ca*]
+#  Specifications of one or more certificate signing endpoints
+#  Defaults to undef
+#
+# [*force_new_cluster*]
+#  Force create a new cluster from current state
+#  Defaults to false
+#
+# [*listen_addr*]
+#  The address that your node will listen to the cluster for raft.
+#  On multihomed servers this flag must be passed
+#  Defaults to undef
+#
+# [*max_snapshots*]
+#  Number of additional Raft snapshots to retain
+#  Defaults to undef
+#
+# [*snapshot_interval*]
+#  Number of log entries between Raft snapshots (default 10000)
+#  Defaults to undef
+#
+# [*token*]
+#  The authentication token to join the cluster. The token also defines the type of
+#  node (worker or manager)
+#  Defaults to undef
+#
+# [*manager_ip*]
+#  The ip address of a manager node to join the cluster.
+#  Defaults to undef
+#
+
+
+define docker::swarm(
+
+  $ensure = 'present',
+  $init = false,
+  $join = false,
+  $advertise_addr = undef,
+  $autolock = false,
+  $cert_expiry = undef,
+  $dispatcher_heartbeat = undef,
+  $external_ca = undef,
+  $force_new_cluster = false,
+  $listen_addr = undef,
+  $max_snapshots = undef,
+  $snapshot_interval = undef,
+  $token = undef,
+  $manager_ip = undef,
+  ){
+
+  include docker::params
+
+  $docker_command = "${docker::params::docker_command} swarm"
+  validate_re($ensure, '^(present|absent)$')
+  validate_string($docker_command)
+  validate_string($cert_expiry)
+  validate_string($dispatcher_heartbeat)
+  validate_string($external_ca)
+  validate_string($max_snapshots)
+  validate_string($snapshot_interval)
+  validate_string($token)
+  validate_ip_address($advertise_addr)
+  validate_ip_address($listen_addr)
+  validate_bool($init)
+  validate_bool($join)
+  validate_bool($autolock)
+  validate_bool($force_new_cluster)
+
+  if $init {
+  $docker_swarm_init_flags = docker_swarm_init_flags({
+    init => $init,
+    advertise_addr => $advertise_addr,
+    autolock => $autolock,
+    cert_expiry => $cert_expiry,
+    dispatcher_heartbeat => $dispatcher_heartbeat,
+    external_ca => $external_ca,
+    force_new_cluster => $force_new_cluster,
+    listen_addr => $listen_addr,
+    max_snapshots => $max_snapshots,
+    snapshot_interval => $snapshot_interval,
+    })
+
+  $exec_init = "${docker_command} ${docker_swarm_init_flags}"
+  $unless_init = 'docker info | grep -w "Swarm: active"'
+
+  exec { 'Swarm init':
+    command     => $exec_init,
+    environment => 'HOME=/root',
+    path        => ['/bin', '/usr/bin'],
+    timeout     => 0,
+    unless      => $unless_init,
+    }
+  }
+
+  if $join {
+  $docker_swarm_join_flags = docker_swarm_join_flags({
+    join => $join,
+    advertise_addr => $advertise_addr,
+    listen_addr => $listen_addr,
+    token => $token,
+    })
+
+  $exec_join = "${docker_command} ${docker_swarm_join_flags} ${manager_ip}"
+  $unless_join = 'docker info | grep -w "Swarm: active"'
+
+  exec { 'Swarm join':
+    command     => $exec_join,
+    environment => 'HOME=/root',
+    path        => ['/bin', '/usr/bin'],
+    timeout     => 0,
+    unless      => $unless_join,
+    }
+  }
+
+  if $ensure == 'absent' {
+    exec { 'Leave swarm':
+      command => 'docker swarm leave --force',
+      onlyif  => 'docker info | grep -w "Swarm: active"',
+      path    => ['/bin', '/usr/bin'],
+    }
+  }
+}

--- a/spec/defines/swarm_spec.rb
+++ b/spec/defines/swarm_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'docker::swarm', :type => :define do
+  let(:title) { 'create swarm' }
+	let(:facts) { {
+		:osfamily                  => 'Debian',
+		:operatingsystem           => 'Debian',
+		:lsbdistid                 => 'Debian',
+		:lsbdistcodename           => 'jessie',
+		:kernelrelease             => '3.2.0-4-amd64',
+		:operatingsystemmajrelease => '8',
+	} }
+
+  context 'with ensure => present and swarm init' do
+    let(:params) { {
+	    'init'           => true,
+	    'advertise_addr' => '192.168.1.1',
+            'listen_addr'    => '192.168.1.1',    
+    } }
+    it { is_expected.to compile.with_all_deps }
+    it { should contain_exec('Swarm init').with_command(/docker swarm init/) }
+  end
+
+  context 'with ensure => present and swarm join' do
+    let(:params) { {
+	    'join'           => true,
+	    'advertise_addr' => '192.168.1.1',
+            'listen_addr'    => '192.168.1.1',
+	    'token'          => 'foo',
+	    'manager_ip'     => '192.168.1.2'
+    } }
+    it { is_expected.to compile.with_all_deps }
+    it { should contain_exec('Swarm join').with_command(/docker swarm join/) }
+  end
+
+  context 'with ensure => absent' do
+    let(:params) { {
+	    'ensure'         => 'absent',
+	    'join'           => true,
+	    'advertise_addr' => '192.168.1.1',
+            'listen_addr'    => '192.168.1.1',
+	    'token'          => 'foo',
+	    'manager_ip'     => '192.168.1.2'
+    } }
+    it { is_expected.to compile.with_all_deps }
+    it { should contain_exec('Leave swarm').with_command(/docker swarm leave --force/) }
+  end
+end


### PR DESCRIPTION
This PR adds Swarm mode. It contains 2 custom parsers. One to create the cluster and the other to join the cluster. In the class docker::swarm we have the configuration for the define type, there is validations on all inputs. By default, the class is not included if you just call the parent class ```include docker``` This was modelled off the existing ```docker::compose``` class 