### PR TITLE
Runscripts

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -325,15 +325,15 @@ define docker::run(
 
     }
     else {
-      file { $initscript:
-        ensure  => present,
-        content => template($init_template),
-        mode    => $mode,
-      }
 
       file { $runscript:
         ensure  => present,
         content => template($runscript_template),
+        mode    => $mode,
+      } ->
+      file { $initscript:
+        ensure  => present,
+        content => template($init_template),
         mode    => $mode,
       }
 

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -250,6 +250,8 @@ define docker::run(
           ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
           $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template = 'docker/etc/systemd/system/docker-run.erb'
+          $runscript      = "/etc/docker/${service_prefix}${sanitised_title}.sh"
+          $runscript_template = 'docker/etc/docker/docker-run.erb'
           $uses_systemd = true
           $mode = '0644'
         } else {
@@ -269,6 +271,8 @@ define docker::run(
         } else {
           $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template  = 'docker/etc/systemd/system/docker-run.erb'
+          $runscript      = "/etc/docker/${service_prefix}${sanitised_title}.sh"
+          $runscript_template = 'docker/etc/docker/docker-run.erb'
           $hasstatus      = true
           $mode           = '0644'
           $uses_systemd   = true
@@ -277,6 +281,8 @@ define docker::run(
       'Archlinux': {
         $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
         $init_template  = 'docker/etc/systemd/system/docker-run.erb'
+        $runscript      = "/etc/docker/${service_prefix}${sanitised_title}.sh"
+        $runscript_template = 'docker/etc/docker/docker-run.erb'
         $hasstatus      = true
         $mode           = '0644'
         $uses_systemd   = true
@@ -322,6 +328,12 @@ define docker::run(
       file { $initscript:
         ensure  => present,
         content => template($init_template),
+        mode    => $mode,
+      }
+
+      file { $runscript:
+        ensure  => present,
+        content => template($runscript_template),
         mode    => $mode,
       }
 

--- a/templates/etc/docker/docker-run.erb
+++ b/templates/etc/docker/docker-run.erb
@@ -1,0 +1,9 @@
+<%- if @remove_container_on_start %>
+/usr/bin/<%= @docker_command %> run \
+        <%= @docker_run_flags %> \
+        --name <%= @sanitised_title %> \
+        <%= @image %> \
+        <% if @command %> <%= @command %><% end %>
+<% else %>
+/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
+<% end -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -41,14 +41,7 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 <% end -%>
 <%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
-<%- if @remove_container_on_start %>
-ExecStart=/usr/bin/<%= @docker_command %> run \
-        <%= @docker_run_flags %> \
-        --name <%= @sanitised_title %> \
-        <%= @image %> \
-        <% if @command %> <%= @command %><% end %>
-<% else %>
-ExecStart=/usr/bin/<%= @docker_command %> start -a <%= @sanitised_title %>
+ExecStart=/bin/bash /etc/docker/<%= @service_prefix %><%= @sanitised_title %>.sh
 <% end -%>
 <%- if @before_stop %>ExecStop=-<%= @before_stop %>
 <% end -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -42,7 +42,6 @@ ExecStartPre=-/usr/bin/<%= @docker_command %> kill <%= @sanitised_title %>
 <%- if @pull_on_start %>ExecStartPre=-/usr/bin/<%= @docker_command %> pull <%= @image %>
 <% end -%>
 ExecStart=/bin/bash /etc/docker/<%= @service_prefix %><%= @sanitised_title %>.sh
-<% end -%>
 <%- if @before_stop %>ExecStop=-<%= @before_stop %>
 <% end -%>
 ExecStop=-/usr/bin/<%= @docker_command %> stop --time=<%= @stop_wait_time %> <%= @sanitised_title %>


### PR DESCRIPTION
Commands need to be escaped in systemd. See https://www.freedesktop.org/software/systemd/man/systemd-escape.html.

An easier work around is to export the run command into a script, and run this instead.