### PR TITLE
Entrypoint plumbing

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -26,6 +26,10 @@ module Puppet::Parser::Functions
       flags << "-m #{opts['memory_limit']}"
     end
 
+    if opts['entrypoint']
+      flags << "--entrypoint '#{opts['entrypoint'].shellescape}'"
+    end
+
     cpusets = [opts['cpuset']].flatten.compact
     unless cpusets.empty?
       value = cpusets.join(',')

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -109,6 +109,7 @@ define docker::run(
   $remove_volume_on_stop = false,
   $stop_wait_time = 0,
   $syslog_identifier = undef,
+  $entrypoint = false,
 ) {
   include docker::params
   if ($socket_connect != []) {
@@ -178,6 +179,10 @@ define docker::run(
     $valid_detach = $detach
   }
 
+  if $entrypoint {
+    validate_string($entrypoint)
+  }
+
   $extra_parameters_array = any2array($extra_parameters)
   $after_array = any2array($after)
   $depends_array = any2array($depends)
@@ -189,6 +194,7 @@ define docker::run(
     disable_network => $disable_network,
     dns             => any2array($dns),
     dns_search      => any2array($dns_search),
+    entrypoint      => $entrypoint,
     env             => any2array($env),
     env_file        => any2array($env_file),
     expose          => any2array($expose),

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -708,6 +708,16 @@ require 'spec_helper'
         it { should contain_exec("remove container docker-sample").with_command('docker rm -v sample') }
       end
 
+      context 'when passing an entrypoint' do
+        let(:params) { {'entrypoint' => '/bin/bash', 'image' => 'base'} }
+        it { should contain_file(initscript).with_content(/--entrypoint '\/bin\/bash'/) }
+      end
+
+      context 'when not passing an entrypoint' do
+        let(:params) { {'command' => 'command', 'image' => 'base'} }
+        it { should contain_file(initscript).without_content(/--entrypoint ''/) }
+      end
+
     end
   end
 


### PR DESCRIPTION
Support --entrypoint as a first-class parameter for docker::run 

Addresses #303 

I ran the unit tests in docker. I couldn't get my vagrant setup working for some reason. I'll try and take another look. The change is pretty straightforward, and I'd expect the acceptance test to pass, once I get it figured out.