### PR TITLE
Add new docker repos for Debian and Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,8 +79,8 @@ class docker::params {
     'Debian' : {
       case $::operatingsystem {
         'Ubuntu' : {
-          $package_release = "ubuntu-${::lsbdistcodename}"
           if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+            $package_release = "ubuntu-${::lsbdistcodename}"
             $service_provider        = 'systemd'
             $storage_config          = '/etc/default/docker-storage'
             $service_config_template = 'docker/etc/sysconfig/docker.systemd.erb'
@@ -91,13 +91,14 @@ class docker::params {
             $package_name            = 'docker-engine'
             include docker::systemd_reload
           } else {
+            $package_release = "${::lsbdistcodename}"
             $service_config_template = 'docker/etc/default/docker.erb'
             $service_overrides_template = undef
             $service_provider        = 'upstart'
             $service_hasstatus       = true
             $service_hasrestart      = false
             $storage_config          = undef
-            $package_source_location = "[arch=amd64] https://download.docker.com/linux/ubuntu ${::lsbdistcodename}"
+            $package_source_location = "[arch=amd64] https://download.docker.com/linux/ubuntu"
             $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
             $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
             $package_repos           = 'stable'
@@ -105,8 +106,8 @@ class docker::params {
           }
         }
         default: {
-          $package_release = "debian-${::lsbdistcodename}"
-          $package_source_location = "[arch=amd64] https://download.docker.com/linux/debian ${::lsbdistcodename}"
+          $package_release = "${::lsbdistcodename}"
+          $package_source_location = "[arch=amd64] https://download.docker.com/linux/debian"
           $package_key_source      = 'https://download.docker.com/linux/debian/gpg'
           $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
           $package_repos           = 'stable'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,6 +87,7 @@ class docker::params {
             $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
             $service_hasstatus       = true
             $service_hasrestart      = true
+            $package_repos           = 'main'
             include docker::systemd_reload
           } else {
             $service_config_template = 'docker/etc/default/docker.erb'
@@ -95,10 +96,18 @@ class docker::params {
             $service_hasstatus       = true
             $service_hasrestart      = false
             $storage_config          = undef
+            $package_source_location = "deb [arch=amd64] https://download.docker.com/linux/ubuntu ${::lsbdistcodename}"
+            $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
+            $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+            $package_repos           = 'stable'
           }
         }
         default: {
           $package_release = "debian-${::lsbdistcodename}"
+          $package_source_location = "deb [arch=amd64] https://download.docker.com/linux/debian ${::lsbdistcodename}"
+          $package_key_source      = 'https://download.docker.com/linux/debian/gpg'
+          $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+          $package_repos           = 'stable'
           if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
             $service_provider           = 'systemd'
             $storage_config             = '/etc/default/docker-storage'
@@ -123,7 +132,7 @@ class docker::params {
       $service_name = $service_name_default
       $docker_command = $docker_command_default
       $docker_group = $docker_group_default
-      $package_repos = 'main'
+      #$package_repos = 'main'
       $use_upstream_package_source = true
       $pin_upstream_package_source = true
       $apt_source_pin_level = 10
@@ -135,9 +144,9 @@ class docker::params {
       $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
       $package_cs_key_source = 'http://packages.docker.com/1.9/apt/gpg'
       $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
-      $package_source_location = 'http://apt.dockerproject.org/repo'
-      $package_key_source = 'http://apt.dockerproject.org/gpg'
-      $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
+      #$package_source_location = 'http://apt.dockerproject.org/repo'
+      #$package_key_source = 'http://apt.dockerproject.org/gpg'
+      #$package_key = '58118E89F3A912897C070ADBF76221572C52609D'
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
         ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,6 +79,8 @@ class docker::params {
     'Debian' : {
       case $::operatingsystem {
         'Ubuntu' : {
+          $package_source_location = '[arch=amd64] https://download.docker.com/linux/ubuntu'
+          $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
           if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
             $package_release = "ubuntu-${::lsbdistcodename}"
             $service_provider        = 'systemd'
@@ -87,8 +89,6 @@ class docker::params {
             $service_overrides_template = 'docker/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb'
             $service_hasstatus       = true
             $service_hasrestart      = true
-            $package_repos           = 'main'
-            $package_name            = 'docker-engine'
             include docker::systemd_reload
           } else {
             $package_release = "${::lsbdistcodename}"
@@ -98,20 +98,12 @@ class docker::params {
             $service_hasstatus       = true
             $service_hasrestart      = false
             $storage_config          = undef
-            $package_source_location = "[arch=amd64] https://download.docker.com/linux/ubuntu"
-            $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
-            $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
-            $package_repos           = 'stable'
-            $package_name            = 'docker-ce'
           }
         }
         default: {
           $package_release = "${::lsbdistcodename}"
-          $package_source_location = "[arch=amd64] https://download.docker.com/linux/debian"
+          $package_source_location = '[arch=amd64] https://download.docker.com/linux/debian'
           $package_key_source      = 'https://download.docker.com/linux/debian/gpg'
-          $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
-          $package_repos           = 'stable'
-          $package_name            = 'docker-ce'
           if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
             $service_provider           = 'systemd'
             $storage_config             = '/etc/default/docker-storage'
@@ -132,11 +124,11 @@ class docker::params {
       }
 
       $manage_epel = false
-      #$package_name = $package_name_default
+      $package_name = 'docker-ce'
       $service_name = $service_name_default
       $docker_command = $docker_command_default
       $docker_group = $docker_group_default
-      #$package_repos = 'main'
+      $package_repos = 'stable'
       $use_upstream_package_source = true
       $pin_upstream_package_source = true
       $apt_source_pin_level = 10
@@ -148,9 +140,7 @@ class docker::params {
       $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
       $package_cs_key_source = 'http://packages.docker.com/1.9/apt/gpg'
       $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
-      #$package_source_location = 'http://apt.dockerproject.org/repo'
-      #$package_key_source = 'http://apt.dockerproject.org/gpg'
-      #$package_key = '58118E89F3A912897C070ADBF76221572C52609D'
+      $package_key = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
         ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -81,8 +81,8 @@ class docker::params {
         'Ubuntu' : {
           $package_source_location = '[arch=amd64] https://download.docker.com/linux/ubuntu'
           $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
+          $package_release = "${::lsbdistcodename}"
           if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
-            $package_release = "ubuntu-${::lsbdistcodename}"
             $service_provider        = 'systemd'
             $storage_config          = '/etc/default/docker-storage'
             $service_config_template = 'docker/etc/sysconfig/docker.systemd.erb'
@@ -91,7 +91,6 @@ class docker::params {
             $service_hasrestart      = true
             include docker::systemd_reload
           } else {
-            $package_release = "${::lsbdistcodename}"
             $service_config_template = 'docker/etc/default/docker.erb'
             $service_overrides_template = undef
             $service_provider        = 'upstart'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,7 +97,7 @@ class docker::params {
             $service_hasstatus       = true
             $service_hasrestart      = false
             $storage_config          = undef
-            $package_source_location = "deb [arch=amd64] https://download.docker.com/linux/ubuntu ${::lsbdistcodename}"
+            $package_source_location = "[arch=amd64] https://download.docker.com/linux/ubuntu ${::lsbdistcodename}"
             $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
             $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
             $package_repos           = 'stable'
@@ -106,7 +106,7 @@ class docker::params {
         }
         default: {
           $package_release = "debian-${::lsbdistcodename}"
-          $package_source_location = "deb [arch=amd64] https://download.docker.com/linux/debian ${::lsbdistcodename}"
+          $package_source_location = "[arch=amd64] https://download.docker.com/linux/debian ${::lsbdistcodename}"
           $package_key_source      = 'https://download.docker.com/linux/debian/gpg'
           $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
           $package_repos           = 'stable'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,6 +88,7 @@ class docker::params {
             $service_hasstatus       = true
             $service_hasrestart      = true
             $package_repos           = 'main'
+            $package_name            = 'docker-engine'
             include docker::systemd_reload
           } else {
             $service_config_template = 'docker/etc/default/docker.erb'
@@ -100,6 +101,7 @@ class docker::params {
             $package_key_source      = 'https://download.docker.com/linux/ubuntu/gpg'
             $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
             $package_repos           = 'stable'
+            $package_name            = 'docker-ce'
           }
         }
         default: {
@@ -108,6 +110,7 @@ class docker::params {
           $package_key_source      = 'https://download.docker.com/linux/debian/gpg'
           $package_key             = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
           $package_repos           = 'stable'
+          $package_name            = 'docker-ce'
           if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
             $service_provider           = 'systemd'
             $storage_config             = '/etc/default/docker-storage'
@@ -128,7 +131,7 @@ class docker::params {
       }
 
       $manage_epel = false
-      $package_name = $package_name_default
+      #$package_name = $package_name_default
       $service_name = $service_name_default
       $docker_command = $docker_command_default
       $docker_group = $docker_group_default

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -970,7 +970,7 @@ describe 'docker', :type => :class do
       :kernelrelease          => '3.8.0-29-generic'
     } }
     it { should contain_service('docker').with_provider('upstart') }
-    it { should contain_package('docker').with_name('docker-engine').with_ensure('present')  }
+    it { should contain_package('docker').with_name('docker-ce').with_ensure('present')  }
     it { should contain_package('apparmor') }
   end
 

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -48,23 +48,28 @@ describe 'docker', :type => :class do
       if osfamily == 'Ubuntu' or osfamily == 'Debian'
 
         it { should contain_class('apt') }
-        it { should contain_package('docker').with_name('docker-engine').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo') }
-        it { should contain_apt__pin('docker').with_origin('apt.dockerproject.org') }
+        it { should contain_package('docker').with_name('docker-ce').with_ensure('present') }
+      if osfamily == 'Ubuntu'
+        it { should contain_apt__source('docker').with_location('[arch=amd64] https://download.docker.com/linux/ubuntu') }
+      end
+      if osfamily == 'Debian'
+        it { should contain_apt__source('docker').with_location('[arch=amd64] https://download.docker.com/linux/debian') }
+      end
+        it { should contain_apt__pin('docker').with_origin('download.docker.com') }
         it { should contain_package('docker').with_install_options(nil) }
 
         it { should contain_file('/etc/default/docker').without_content(/icc=/) }
 
         context 'with a custom version' do
-          let(:params) { {'version' => '0.5.5' } }
-          it { should contain_package('docker').with_ensure('0.5.5').with_name('docker-engine') }
+          let(:params) { {'version' => '17.03.0-ce' } }
+          it { should contain_package('docker').with_ensure('17.03.0-ce').with_name('docker-ce') }
         end
 
         context 'with no upstream package source' do
           let(:params) { {'use_upstream_package_source' => false } }
           it { should_not contain_apt__source('docker') }
           it { should_not contain_apt__pin('docker') }
-          it { should contain_package('docker').with_name('docker-engine') }
+          it { should contain_package('docker').with_name('docker-ce') }
         end
 
         context 'with no upstream package source' do
@@ -754,7 +759,7 @@ describe 'docker', :type => :class do
       let(:params) { {'use_upstream_package_source' => false } }
       it { should_not contain_apt__source('docker') }
       it { should_not contain_apt__pin('docker') }
-      it { should contain_package('docker').with_name('docker-engine') }
+      it { should contain_package('docker').with_name('docker-ce') }
     end
   end
 


### PR DESCRIPTION
I create new branch to update the new repositories of Docker CE called "**add-new-docker-repos**".

Changes:
-  Add new repos.
-  Rename package name.
-  Modify Spec tests.

Results of Spec tests:

Finished in 3 minutes 11.9 seconds (files took 1.34 seconds to load)
1299 examples, 0 failures, 10 pending


Total resources:   88
Touched resources: 61
Resource coverage: 69.32%

Results of Lint tests:

%{path}:%{linenumber}:%{check}:%{KIND}:%{message}
%{path}:%{linenumber}:%{check}:%{KIND}:%{message}

Results of Syntax tests:

---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml

I cannot exec Beaker tests, but i test this module in Debian Jessie and Ubuntu 16.04.