### PR TITLE
Add support for onlyif in a docker exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ docker::exec { 'cron_allow_root':
   detach       => true,
   container    => 'mycontainer',
   command      => '/bin/echo root >> /usr/lib/cron/cron.allow',
+  onlyif       => 'running',
   tty          => true,
   unless       => 'grep root /usr/lib/cron/cron.allow 2>/dev/null',
 }

--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -8,6 +8,7 @@ define docker::exec(
   $tty = false,
   $container = undef,
   $command = undef,
+  $onlyif = undef,
   $unless = undef,
   $sanitise_name = true,
 ) {
@@ -18,6 +19,7 @@ define docker::exec(
 
   validate_string($container)
   validate_string($command)
+  validate_string($onlyif)
   validate_string($unless)
   validate_bool($detach)
   validate_bool($interactive)
@@ -41,9 +43,16 @@ define docker::exec(
       ''                 => undef,
       default            => "${docker_command} exec ${docker_exec_flags} ${sanitised_container} ${$unless}",
   }
+  $onlyif_command = $onlyif ? {
+    undef     => undef,
+    ''        => undef,
+    'running' => "${docker_command} ps --no-trunc --format='table {{.Names}}' | grep '^${sanitised_container}$'",
+    default   => $onlyif
+  }
 
   exec { $exec:
     environment => 'HOME=/root',
+    onlyif      => $onlyif_command,
     path        => ['/bin', '/usr/bin'],
     timeout     => 0,
     unless      => $unless_command,

--- a/spec/defines/exec_spec.rb
+++ b/spec/defines/exec_spec.rb
@@ -26,6 +26,21 @@ describe 'docker::exec', :type => :define do
 		it { should contain_exec('docker exec --interactive=true container command') }
   end
 
+  context 'when running with onlyif "running"' do
+		let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true, 'onlyif' => 'running'} }
+		it { should contain_exec('docker exec --interactive=true container command').with_onlyif ('docker ps --no-trunc --format=\'table {{.Names}}\' | grep \'^container$\'') }
+  end
+
+  context 'when running without onlyif custom command' do
+		let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true, 'onlyif' => 'custom'} }
+		it { should contain_exec('docker exec --interactive=true container command').with_onlyif ('custom') }
+  end
+
+  context 'when running without onlyif' do
+		let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true} }
+		it { should contain_exec('docker exec --interactive=true container command').with_onlyif (nil) }
+  end
+
   context 'when running with unless' do
 		let(:params) { {'command' => 'command', 'container' => 'container', 'interactive' => true, 'unless' => 'some_command arg1'} }
 		it { should contain_exec('docker exec --interactive=true container command').with_unless ('docker exec --interactive=true container some_command arg1') }


### PR DESCRIPTION
Allow adding a condition to only run the exec in specific cases.
Additionally provide a simple 'running' option that allows checking if
the container is running before attempting an exec in cases where it may
be used to perform config testing before allowing a restart of a
container, but should be skipped if the container is not running.