### PR TITLE
Support refreshonly flag

### DIFF
--- a/manifests/exec.pp
+++ b/manifests/exec.pp
@@ -8,6 +8,7 @@ define docker::exec(
   $tty = false,
   $container = undef,
   $command = undef,
+  $refreshonly = false,
   $unless = undef,
   $sanitise_name = true,
 ) {
@@ -21,6 +22,7 @@ define docker::exec(
   validate_string($unless)
   validate_bool($detach)
   validate_bool($interactive)
+  validate_bool($refreshonly)
   validate_bool($tty)
 
   $docker_exec_flags = docker_exec_flags({
@@ -45,6 +47,7 @@ define docker::exec(
   exec { $exec:
     environment => 'HOME=/root',
     path        => ['/bin', '/usr/bin'],
+    refreshonly => $refreshonly,
     timeout     => 0,
     unless      => $unless_command,
   }


### PR DESCRIPTION
Allow for the refreshonly flag to be passed through to the underlying
exec resource.

This allows for Docker::Exec resources to be defined to only run when
notified, which allows for construction of manifests that can check
whether updated configuration made available to running containers
(provided they are using directory mount binds) are valid before
triggering a service restart.

Use case for this is to test generated nginx configuration for the
running nginx container using a Docker::Exec call that is notified by
the file resource and in turn will notify the service resource to
restart.