### PR TITLE
'pe' is no longer supported by the Forge

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -56,10 +56,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.7.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.4.0"
     }


### PR DESCRIPTION
Remove dependency on 'pe' as it will fail in any metadata-json-lint
tests.