### PR TITLE
Add support for fetching docker-compose from alternate URLs

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -20,17 +20,37 @@
 # [*proxy*]
 #   Proxy to use for downloading Docker Compose.
 #
+# [*baseurl*]
+#   The base URL to use for installation
+#   Defaults to the value set in $docker::params::compose_baseurl.
+#   This URL will have "/${version}/docker-compose-{::kernel}-x86_64"
+#   appended to it. This allows use of a mirror that follows the same
+#   layout as the official repository.
+#
+# [*rawurl*]
+#   Override the raw URL for installation
+#   The default is to build a URL from baseurl. If rawurl is set, the caller is
+#   responsible for ensuring the URL points to the correct version and
+#   architecture.
+#
 class docker::compose(
   $ensure = 'present',
   $version = $docker::params::compose_version,
   $install_path = $docker::params::compose_install_path,
-  $proxy = undef
+  $proxy = undef,
+  $baseurl = $docker::params::compose_baseurl,
+  $rawurl = undef
 ) inherits docker::params {
   validate_string($version)
   validate_re($ensure, '^(present|absent)$')
   validate_absolute_path($install_path)
+  $url_regex = '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$'
+  validate_re($baseurl, $url_regex)
   if $proxy != undef {
-      validate_re($proxy, '^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})(:[\d])?([\/\w \.-]*)*\/?$')
+    validate_re($proxy, $url_regex)
+  }
+  if $rawurl != undef {
+    validate_re($rawurl, $url_regex)
   }
 
   if $ensure == 'present' {
@@ -42,10 +62,15 @@ class docker::compose(
         $proxy_opt = ''
     }
 
+    $url = $rawurl ? {
+      undef   => "${baseurl}/${version}/docker-compose-${::kernel}-x86_64",
+      default =>  $rawurl,
+    }
+
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L ${proxy_opt} https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > ${install_path}/docker-compose-${version}",
+      command => "curl -s -L ${proxy_opt} ${url} > ${install_path}/docker-compose-${version}",
       creates => "${install_path}/docker-compose-${version}",
       require => Package['curl'],
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,6 +74,7 @@ class docker::params {
   $storage_config_template           = 'docker/etc/sysconfig/docker-storage.erb'
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
+  $compose_baseurl                   = 'https://github.com/docker/compose/releases/download'
 
   case $::osfamily {
     'Debian' : {

--- a/spec/unit/compose_spec.rb
+++ b/spec/unit/compose_spec.rb
@@ -40,4 +40,36 @@ describe 'docker::compose', :type => :class do
     end
   end
 
+  context 'when baseurl is provided' do
+    let(:params) { {:baseurl => 'http://fetch.compose.from/here', :version => '1.7.0'} }
+    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
+           'curl -s -L  http://fetch.compose.from/here/1.7.0/docker-compose-Linux-x86_64 > /usr/local/bin/docker-compose-1.7.0')
+    }
+  end
+
+  context 'when baseurl is not a url' do
+    let(:params) { {:baseurl => 'this is not a URL'} }
+    it do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/does not match/)
+    end
+  end
+
+  context 'when rawurl is provided' do
+    let(:params) { {:rawurl => 'http://fetch.compose.from/over-there', :version => '1.7.0'} }
+    it { is_expected.to contain_exec('Install Docker Compose 1.7.0').with_command(
+           'curl -s -L  http://fetch.compose.from/over-there > /usr/local/bin/docker-compose-1.7.0')
+    }
+  end
+
+  context 'when rawurl is not a url' do
+    let(:params) { {:rawurl => 'this is not a URL'} }
+    it do
+      expect {
+        is_expected.to compile
+      }.to raise_error(/does not match/)
+    end
+  end
+
 end


### PR DESCRIPTION
I have added parameters to allow overriding of either the "base" URL or the whole URL when installing docker-compose.

Using baseurl allows you to install from a local mirror of whatever version/architectures you need with the same directory layout as the repository on GitHub.

Using rawurl you can override the entire URL and point to a specific file, dealing with the version and architecture yourself.