### PR TITLE
Require >= 4.6.0 of puppetlabs-stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/garethr/garethr-docker",
   "issues_url": "https://github.com/garethr/garethr-docker/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <= 3.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 0.0.6"}
   ],


### PR DESCRIPTION
I recently updated to the latest version of this module (from v4.0.0) and our version of puppetlabs-stdlib was at v4.1.0 so satisfied dependencies.

I found however that the `validate_integer` function used in `docker::run` was only introduced in puppetlabs-stdlib v4.6.0.

