### PR TITLE
Add support for overlay2.override_kernel_check setting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,6 +279,10 @@
 #   synchronization, to continue even though the configuration may be buggy.
 #   Defaults to true
 #
+# [*overlay2_override_kernel_check*]
+#   Overrides the Linux kernel version check allowing overlay2
+#   Default value is false
+#
 # [*manage_package*]
 #   Won't install or define the docker package, useful if you want to use your own package
 #   Defaults to true
@@ -406,6 +410,7 @@ class docker(
   $dm_use_deferred_deletion          = $docker::params::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
+  $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
   $execdriver                        = $docker::params::execdriver,
   $manage_package                    = $docker::params::manage_package,
   $package_source                    = $docker::params::package_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,7 @@ class docker::params {
   $dm_use_deferred_deletion          = undef
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
+  $overlay2_override_kernel_check    = false
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -41,6 +41,8 @@ other_args="<% -%>
 <% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% else -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/conf.d/docker.gentoo.erb
+++ b/templates/etc/conf.d/docker.gentoo.erb
@@ -41,6 +41,8 @@ DOCKER_OPTS="<% -%>
 <% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% else -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -58,6 +58,8 @@ DOCKER_OPTS="\
 <% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% else -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/sysconfig/docker-storage.erb
+++ b/templates/etc/sysconfig/docker-storage.erb
@@ -33,5 +33,7 @@ DOCKER_STORAGE_OPTIONS="<% -%>
 <% if @dm_use_deferred_deletion %> --storage-opt dm.use_deferred_deletion=<%= @dm_use_deferred_deletion %><% end -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
+<% else -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
 <% end -%>
 "


### PR DESCRIPTION
Add support for `overlay2.override_kernel_check` setting. Tested and working on Centos 7.

This fixes https://github.com/garethr/garethr-docker/issues/662