### PR TITLE
Added '--type image' switch to docker inspect command

### DIFF
--- a/templates/update_docker_image.sh.erb
+++ b/templates/update_docker_image.sh.erb
@@ -7,9 +7,9 @@
 #
 DOCKER_IMAGE=$1
 
-BEFORE=$(docker inspect --format='{{.Id}}' ${DOCKER_IMAGE} 2>/dev/null)
+BEFORE=$(docker inspect --type image --format='{{.Id}}' ${DOCKER_IMAGE} 2>/dev/null)
 <%= @docker_command -%> pull ${DOCKER_IMAGE}
-AFTER=$(docker inspect --format='{{.Id}}' ${DOCKER_IMAGE} 2>/dev/null)
+AFTER=$(docker inspect --type image --format='{{.Id}}' ${DOCKER_IMAGE} 2>/dev/null)
 
 if [[ -z $AFTER ]]; then
   echo "Docker image ${DOCKER_IMAGE} failed to pull!"


### PR DESCRIPTION
When calling the module `docker::image`, a call is made to `update_docker_image.sh` to verify if the SHA256 value of an image has changed after doing a `docker pull`.  To get the SHA256 value, a `docker inspect` call is made and this call is generating an error in /var/log/messages:
`... GET /v1.24/containers/registry/<myregistry>/<myimage>:<imageid>/json returned error: No such container <myregistry>/<myimage>:<imageid>`

This error is happening since `docker inspect` will look for both image and container.  There is now a new CLI switch in `docker inspect` where you can specify that you are looking for an image only (like in this case since we only care about the SHA256 of an image):
`docker inspect --type image <myregistry>/<myimage>:<imageid>`

Adding this `--type image` switch does not make a query for a container, so no error gets written to /var/log/messages.  The puppet module still works, but it would be cleaner if no error is generated.

See this docker [pull request](https://github.com/docker/docker/pull/13187) for more information and background.