### PR TITLE
Replace deprecated apt::source parameters

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -21,11 +21,18 @@ class docker::repos {
           location          => $location,
           release           => $docker::package_release,
           repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
-          required_packages => 'debian-keyring debian-archive-keyring',
-          include_src       => false,
+          key               => { 
+            id     => $package_key,
+            source => $key_source,
+          },
+          include           => {
+            src => false,
+            deb => true,
+          }
         }
+        package { ['debian-keyring', 'debian-archive-keyring']:
+          ensure => present,
+        } -> Apt::Source['docker']
         $url_split = split($location, '/')
         $repo_host = $url_split[2]
         $pin_ensure = $docker::pin_upstream_package_source ? {


### PR DESCRIPTION
A number of apt:source parameters were deprecated, and have now been
removed. This commit migrates to replacements

* key_source is replaced with passing a hash to the key parameter.
* include_src is replaced with passing a hash to the include parameter.
* required_packages has been replaced with explicitly installing them,
and adding a dependency between the package and the apt::source.

I'm not sure if the explicit package installation might cause an issue
with other modules doing the same thing.

This will resolve #607 