### PR TITLE
Tighten up init script permissions

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -118,6 +118,7 @@ define docker::run(
     $docker_command = $docker::params::docker_command
   }
   $service_name = $docker::params::service_name
+  $docker_group = $docker::params::docker_group
 
   validate_re($image, '^[\S]*$')
   validate_re($title, '^[\S]*$')
@@ -128,6 +129,8 @@ define docker::run(
   }
   validate_string($docker_command)
   validate_string($service_name)
+  validate_string($docker_group)
+
   if $command {
     validate_string($command)
   }
@@ -251,12 +254,12 @@ define docker::run(
           $initscript = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template = 'docker/etc/systemd/system/docker-run.erb'
           $uses_systemd = true
-          $mode = '0644'
+          $mode = '0640'
         } else {
           $uses_systemd = false
           $initscript = "/etc/init.d/${service_prefix}${sanitised_title}"
           $init_template = 'docker/etc/init.d/docker-run.erb'
-          $mode = '0755'
+          $mode = '0750'
         }
       }
       'RedHat': {
@@ -264,13 +267,13 @@ define docker::run(
           $initscript     = "/etc/init.d/${service_prefix}${sanitised_title}"
           $init_template  = 'docker/etc/init.d/docker-run.erb'
           $hasstatus      = undef
-          $mode           = '0755'
+          $mode           = '0750'
           $uses_systemd   = false
         } else {
           $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
           $init_template  = 'docker/etc/systemd/system/docker-run.erb'
           $hasstatus      = true
-          $mode           = '0644'
+          $mode           = '0640'
           $uses_systemd   = true
         }
       }
@@ -278,14 +281,14 @@ define docker::run(
         $initscript     = "/etc/systemd/system/${service_prefix}${sanitised_title}.service"
         $init_template  = 'docker/etc/systemd/system/docker-run.erb'
         $hasstatus      = true
-        $mode           = '0644'
+        $mode           = '0640'
         $uses_systemd   = true
       }
       'Gentoo': {
         $initscript     = "/etc/init.d/${service_prefix}${sanitised_title}"
         $init_template  = 'docker/etc/init.d/docker-run.gentoo.erb'
         $hasstatus      = true
-        $mode           = '0775'
+        $mode           = '0770'
         $uses_systemd   = false
       }
       default: {
@@ -322,6 +325,8 @@ define docker::run(
       file { $initscript:
         ensure  => present,
         content => template($init_template),
+        owner   => 'root',
+        group   => $docker_group,
         mode    => $mode,
       }
 


### PR DESCRIPTION
Re: #637

Obviously, implementing docker secrets in this module is the correct solution to the problem. But this PR helps mitigate a potential credential leak in the current code.