### PR TITLE
Make docker::run use $service_name instead of "docker"

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -117,7 +117,7 @@ define docker::run(
   }else {
     $docker_command = $docker::params::docker_command
   }
-  $service_name = $docker::params::service_name
+  $service_name = $docker::service_name
 
   validate_re($image, '^[\S]*$')
   validate_re($title, '^[\S]*$')

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -147,12 +147,12 @@ class docker::service (
 
   case $service_provider {
     'systemd': {
-      file { '/etc/systemd/system/docker.service.d':
+      file { "/etc/systemd/system/${service_name}.service.d":
         ensure => directory
       }
 
       if $service_overrides_template {
-        file { '/etc/systemd/system/docker.service.d/service-overrides.conf':
+        file { "/etc/systemd/system/${service_name}.service.d/service-overrides.conf":
           ensure  => present,
           content => template($service_overrides_template),
           notify  => Exec['docker-systemd-reload-before-service'],

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -1,10 +1,10 @@
 <%-
-	@required_start = ["$network", "docker"] +
+	@required_start = ["$network", @service_name] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}"} +
 		@depend_services_array
 
-	@required_stop = ["$network", "docker"] +
+	@required_stop = ["$network", @service_name] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}"} +
 		@depend_services_array
 -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -1,10 +1,11 @@
 <%-
-	@after = ["docker.service"] +
+  docker_service_name = scope.lookupvar('docker::service_name')
+  @after = ["#{docker_service_name}.service"] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
 		@depend_services_array.map{|s| "#{s}.service"}
 	@wants = @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}
-	@requires = ["docker.service"] +
+  @requires = ["#{docker_service_name}.service"] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
 		@depend_services_array.map{|s| "#{s}.service"}
 -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -1,11 +1,10 @@
 <%-
-  docker_service_name = scope.lookupvar('docker::service_name')
-  @after = ["#{docker_service_name}.service"] +
+  @after = ["#{@service_name}.service"] +
 		@sanitised_after_array.map{ |s| "#{@service_prefix}#{s}.service"} +
 		@sanitised_depends_array.map{ |s| "#{@service_prefix}#{s}.service"} +
 		@depend_services_array.map{|s| "#{s}.service"}
 	@wants = @sanitised_after_array.map{ |a| "#{@service_prefix}#{a}.service"}
-  @requires = ["#{docker_service_name}.service"] +
+  @requires = ["#{@service_name}.service"] +
 		@sanitised_depends_array.map{ |d| "#{@service_prefix}#{d}.service"} +
 		@depend_services_array.map{|s| "#{s}.service"}
 -%>


### PR DESCRIPTION
When using the module with 'docker-latest' packages from RedHat the systemd service of docker is also 'docker-latest'.
There is already a $service_name variable for this, but 'docker' is still hardcoded in some strings.

This replaces hardcoded 'docker' strings with $service_name.