### PR TITLE
Add fact for 'docker info'

### DIFF
--- a/lib/facter/docker_info.rb
+++ b/lib/facter/docker_info.rb
@@ -1,0 +1,11 @@
+require 'json'
+
+Facter.add(:docker_info) do
+  setcode do
+    if Facter::Util::Resolution.which('docker')
+      output = Facter::Util::Resolution.exec('docker info --format "{{json .}}" 2>&1')
+      JSON.parse(output)
+    end
+  end
+end
+


### PR DESCRIPTION
This adds a fact docker_info which contains the
information of 'docker info' output.