### PR TITLE
Add docker_stack type and provider

### DIFF
--- a/lib/puppet/provider/docker_stack/docker_stack.rb
+++ b/lib/puppet/provider/docker_stack/docker_stack.rb
@@ -1,0 +1,48 @@
+Puppet::Type.type(:docker_stack).provide(:docker_stack) do
+  desc 'Support for Puppet running Docker Stack.'
+
+  mk_resource_methods
+  commands :docker => '/usr/bin/docker'
+
+  def exists?
+    Puppet.info("Checking services for compose project #{resource[:namestack]}")
+    compose_file = YAML.load(File.read(resource[:path]))
+    services = `/usr/bin/docker stack ls | /bin/grep #{resource[:namestack]} | /usr/bin/awk -F " " '{print $2}'`.to_i
+    count=0
+    case compose_file["version"]
+    when /^3(\.\d{1,})?$/
+      Puppet.info("Checking the services in the stack #{resource[:namestack]}")
+      compose_file["services"].each_key.collect { |key|
+        count += 1
+      }
+    else
+      raise(Puppet::Error, "Unsupported docker compose file syntax version \"#{compose_file["version"]}\"!")
+    end
+    if (services == count) then
+      true
+    else
+      false
+    end
+  end
+
+  def create
+    Puppet.info("Running compose project #{resource[:namestack]}")
+    args = ['stack', 'deploy', '-c', resource[:path], resource[:namestack]].compact
+    docker(args)
+  end
+
+  def destroy
+    Puppet.info("Removing all containers for stack project #{resource[:namestack]}")
+    kill_args = ['stack', 'rm', resource[:namestack]].compact
+    docker(kill_args)
+  end
+
+  def redeploy
+    if exists?
+      Puppet.info("Redeploy compose project #{resource[:namestack]}")
+      args = ['stack', 'up', '-c', resource[:path], resource[:namestack]].compact
+      docker(args)
+    end
+  end
+
+end

--- a/lib/puppet/type/docker_stack.rb
+++ b/lib/puppet/type/docker_stack.rb
@@ -1,0 +1,42 @@
+Puppet::Type.newtype(:docker_stack) do
+
+  @doc=%q{Manage Docker stacks in compose v3.
+
+    Example:
+
+      docker_stack { '/root/docker-compose.yml':
+        ensure    => present,
+        namestack => 'test',
+      }
+  }
+
+  ensurable
+
+  newparam(:namestack) do
+    desc 'Name of the Docker Stack.'
+  end
+
+  newparam(:path, :namevar => true) do
+    desc 'Absolute path of docker-compose.yml.'
+    validate do |value|
+      unless Puppet::Util.absolute_path?(value)
+        raise Puppet::Error, "File paths must be fully qualified, not '#{value}'"
+      end
+    end
+  end
+
+  def refresh
+    provider.redeploy
+  end
+
+  autorequire(:file) do
+    self[:path]
+  end
+
+  validate do
+    unless self[:path]
+      raise(Puppet::Error, "path is a required attribute")
+    end
+  end
+
+end


### PR DESCRIPTION
I leave my last contribution, the type and provider **docker_stack** .
The **docker_stack** provider allows you to deploy a compose file to v3. To call it, the following syntax would be used:

```
docker_stack {'path-to-compose-v3.yml':
   ensure    => 'present',
   namestack => 'name-of-the-stack',
}
```

The provider have been tested in my working environment and put into production. I'm sorry I did not write the rspec tests, but as I already tell you because of my work urgency, I do not have time to do this. If necessary to do the pull request my master branch has the changes. I feel free to clone my changes, add what is missing and do the pull request.

Regards!