### PR TITLE
Add swarm_extract_token facter

### DIFF
--- a/lib/facter/swarm_extract_tokens.rb
+++ b/lib/facter/swarm_extract_tokens.rb
@@ -1,0 +1,26 @@
+Facter.add(:swarm_extract_tokens, :type => :aggregate) do
+
+  chunk(:token_manager) do
+    tokens = {}
+    token = Facter::Core::Execution.execute('/usr/bin/docker swarm join-token -q manager 2> /dev/null')
+      if token.nil?
+        tokens["swarm_tokens"] = {:manager => nil }
+      else
+        tokens["swarm_tokens"] = {:manager => token}
+      end
+
+    tokens
+  end
+
+  chunk(:token_worker) do
+    tokens = {}
+    token = Facter::Core::Execution.execute('/usr/bin/docker swarm join-token -q worker 2> /dev/null')
+      if token.nil?
+        tokens["swarm_tokens"] = {:worker => nil }
+      else
+        tokens["swarm_tokens"] = {:worker => token}
+      end
+
+    tokens
+  end
+end


### PR DESCRIPTION
I leave my last contribution, the **swarm_extract_tokens** facter to extract the swarm tokens with the idea of using them as exported resources, through the puppetDB, etc.

Facter **swarm_extract_tokens** extracts in hash format both manager and worker tokens. An output of this facter is as follows:

```
swarm_extract_tokens => {
  swarm_tokens => {
    manager => "SWMTKN-1-2nv8qxa5npe850c4hx3utvcn7tdmmg08d70yw6nrzlu5et1kil-f2qik9f2ui4ciuvnf6b8uuxs5",
    worker => "SWMTKN-1-2nv8qxa5npe850c4hx3utvcn7tdmmg08d70yw6nrzlu5et1kil-9unklwesgt1njskt7gjovny96"
  }
}
```

The facter have been tested in my working environment and put into production. I'm sorry I did not write the rspec tests, but as I already tell you because of my work urgency, I do not have time to do this. If necessary to do the pull request my master branch has the changes. I feel free to clone my changes, add what is missing and do the pull request.

Regards!