### PR TITLE
fixes a bug introduced by changes upstream in the apt module.

### DIFF
--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -1,0 +1,30 @@
+require 'facter'
+require 'json'
+
+def interfaces
+  Facter.value(:interfaces).split(',')
+end
+
+Facter.add(:docker) do
+  setcode do
+    if Facter::Util::Resolution.which('docker')
+      docker = Hash.new
+      docker['network'] = Hash.new
+      docker['network']['managed_interfaces'] = Hash.new
+      network_list = Facter::Util::Resolution.exec('docker network ls | tail -n +2')
+      docker_network_names = Array.new
+      network_list.each_line {|line| docker_network_names.push line.split[1] }
+      docker_network_ids = Array.new
+      network_list.each_line {|line| docker_network_ids.push line.split[0] }
+      docker_network_names.each do |network|
+        inspect = JSON.parse(Facter::Util::Resolution.exec("docker network inspect #{network}"))
+        docker['network'][network] = inspect[0]
+        network_id = docker['network'][network]['Id'][0..11]
+        interfaces.each do |iface|
+          docker['network']['managed_interfaces'][iface] = network if iface =~ /#{network_id}/
+        end
+      end
+      docker
+    end
+  end
+end

--- a/lib/facter/docker.rb
+++ b/lib/facter/docker.rb
@@ -1,30 +1,119 @@
+# frozen_string_literal: true
+
 require 'facter'
 require 'json'
+require 'etc'
+
+Facter.add(:docker_systemroot) do
+  confine osfamily: :windows
+  setcode do
+    Puppet::Util.get_env('SystemRoot')
+  end
+end
+
+Facter.add(:docker_program_files_path) do
+  confine osfamily: :windows
+  setcode do
+    Puppet::Util.get_env('ProgramFiles')
+  end
+end
+
+Facter.add(:docker_program_data_path) do
+  confine osfamily: :windows
+  setcode do
+    Puppet::Util.get_env('ProgramData')
+  end
+end
+
+Facter.add(:docker_user_temp_path) do
+  confine osfamily: :windows
+  setcode do
+    Puppet::Util.get_env('TEMP')
+  end
+end
+
+Facter.add(:docker_home_dirs) do
+  confine kernel: 'Linux'
+  setcode do
+    home_dirs = {}
+    Etc.passwd do |user|
+      home_dirs[user.name] = user.dir
+    end
+    home_dirs
+  end
+end
+
+docker_command = if Facter.value(:kernel) == 'windows'
+                   'powershell -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -c docker'
+                 else
+                   'docker'
+                 end
 
 def interfaces
   Facter.value(:interfaces).split(',')
 end
 
-Facter.add(:docker) do
+Facter.add(:docker_client_version) do
+  setcode do
+    docker_version = Facter.value(:docker_version)
+    docker_version['Client']['Version'] if docker_version
+  end
+end
+
+Facter.add(:docker_server_version) do
+  setcode do
+    docker_version = Facter.value(:docker_version)
+    if docker_version && !docker_version['Server'].nil? && docker_version['Server'].is_a?(Hash)
+      docker_version['Server']['Version']
+    else
+      nil
+    end
+  end
+end
+
+Facter.add(:docker_version) do
   setcode do
     if Facter::Util::Resolution.which('docker')
-      docker = Hash.new
-      docker['network'] = Hash.new
-      docker['network']['managed_interfaces'] = Hash.new
-      network_list = Facter::Util::Resolution.exec('docker network ls | tail -n +2')
-      docker_network_names = Array.new
-      network_list.each_line {|line| docker_network_names.push line.split[1] }
-      docker_network_ids = Array.new
-      network_list.each_line {|line| docker_network_ids.push line.split[0] }
-      docker_network_names.each do |network|
-        inspect = JSON.parse(Facter::Util::Resolution.exec("docker network inspect #{network}"))
-        docker['network'][network] = inspect[0]
-        network_id = docker['network'][network]['Id'][0..11]
-        interfaces.each do |iface|
-          docker['network']['managed_interfaces'][iface] = network if iface =~ /#{network_id}/
+      value = Facter::Core::Execution.execute(
+        "#{docker_command} version --format '{{json .}}'",
+      )
+      val = JSON.parse(value)
+    end
+    val
+  end
+end
+
+Facter.add(:docker) do
+  setcode do
+    docker_version = Facter.value(:docker_client_version)
+    if docker_version !~ %r{1[.][0-9][0-2]?[.]\w+}
+      if Facter::Util::Resolution.which('docker')
+        docker_json_str = Facter::Util::Resolution.exec(
+          "#{docker_command} info --format '{{json .}}'",
+        )
+        begin
+          docker = JSON.parse(docker_json_str)
+          docker['network'] = {}
+
+          docker['network']['managed_interfaces'] = {}
+          network_list = Facter::Util::Resolution.exec("#{docker_command} network ls | tail -n +2")
+          docker_network_names = []
+          network_list.each_line { |line| docker_network_names.push line.split[1] }
+          docker_network_ids = []
+          network_list.each_line { |line| docker_network_ids.push line.split[0] }
+          docker_network_names.each do |network|
+            inspect = JSON.parse(Facter::Util::Resolution.exec("#{docker_command} network inspect #{network}"))
+            docker['network'][network] = inspect[0]
+            network_id = docker['network'][network]['Id'][0..11]
+            interfaces.each do |iface|
+              docker['network']['managed_interfaces'][iface] = network if iface =~ %r{#{network_id}}
+            end
+          end
+          docker
+        rescue JSON::ParserError
+          nil
         end
       end
-      docker
     end
   end
 end

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -18,14 +18,21 @@ class docker::repos {
           $package_key = $docker::package_key
         }
         apt::source { 'docker':
-          location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
-          required_packages => 'debian-keyring debian-archive-keyring',
-          include_src       => false,
+          location => $location,
+          release  => $docker::package_release,
+          repos    => $docker::package_repos,
+          key      => {
+            id     => $package_key,
+            source => $key_source,
+          },
+          include  => {
+            src => false,
+            deb => true,
+          }
         }
+        package { ['debian-keyring', 'debian-archive-keyring']:
+          ensure => present,
+        } -> Apt::Source['docker']
         $url_split = split($location, '/')
         $repo_host = $url_split[2]
         $pin_ensure = $docker::pin_upstream_package_source ? {


### PR DESCRIPTION
This Pull Request addresses bug introduced by updated apt module.

It appears that ruby 1.9.3 needs to be removed from travis along with STRICT_VARIABLES is no longer supported in APT Module v2.1

That seems to be the cause of the failed tests

See #607 for more detail on what this addresses.