### PR TITLE
Use line breaks and continuation for run flags

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -76,6 +76,8 @@ module Puppet::Parser::Functions
       flags << param
     end
 
-    flags.flatten.join(" ")
+    # Some software (systemd) will truncate very long lines using glibc's max
+    # line length. Wrap options across multiple lines with '\' to avoid
+    flags.flatten.join(" \\\n        ")
   end
 end


### PR DESCRIPTION
Switch from joining the docker_run_flags using spaces to new lines and
continuations to avoid hitting the glibc MAX_LINE limit used by systemd.

As docker_run_flags is used to provide the args to init scripts and
systemd, switching it to use line continuation and newlines is
sufficient to ensure that systemd/initscritps do not hit any limit
imposed by glibc on a readline and at the same time know to continue
processing onto the next line for the rest of the command to be run.

Fixes #660