### PR TITLE
fix for cs package not being applied

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -349,6 +349,8 @@ class docker(
   $ensure                            = $docker::params::ensure,
   $prerequired_packages              = $docker::params::prerequired_packages,
   $docker_cs                         = $docker::params::docker_cs,
+  $package_cs_source_location        = $docker::params::package_cs_source_location,
+  $package_cs_key_source             = $docker::params::package_cs_key_source,
   $tcp_bind                          = $docker::params::tcp_bind,
   $tls_enable                        = $docker::params::tls_enable,
   $tls_verify                        = $docker::params::tls_verify,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -246,6 +246,8 @@ class docker::params {
       $package_repos = undef
       $package_release = undef
       $use_upstream_package_source = false
+      $package_cs_source_location = undef
+      $package_cs_key_source = undef
       $package_name = 'docker'
       $service_name = $service_name_default
       $docker_command = $docker_command_default
@@ -272,6 +274,8 @@ class docker::params {
       $package_repos = undef
       $package_release = undef
       $use_upstream_package_source = false
+      $package_cs_source_location = undef
+      $package_cs_key_source = undef
       $package_name = 'app-emulation/docker'
       $service_name = $service_name_default
       $docker_command = $docker_command_default
@@ -295,6 +299,8 @@ class docker::params {
       $package_key_source = undef
       $package_source_location = undef
       $package_key = undef
+      $package_cs_source_location = undef
+      $package_cs_key_source = undef
       $package_repos = undef
       $package_release = undef
       $use_upstream_package_source = true


### PR DESCRIPTION
This PR fixes the issue that you could not apply a CS package on RHEL as the variables '$package_cs_source_location` and `$package_cs_key_source` where not in the init.pp  