### PR TITLE
support dockerd and docker daemon in unit files

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,10 +1,14 @@
 fixtures:
-  forge_modules:
-    stdlib: 'puppetlabs-stdlib'
-    epel: 'stahnma-epel'
+#  forge_modules:
+#    - 'puppetlabs-stdlib'
+#    - 'stahnma-epel'
   repositories:
     apt:
-      repo: git://github.com/puppetlabs/puppetlabs-apt.git
+      repo: https://github.com/puppetlabs/puppetlabs-apt.git
       ref: 2.1.0
+    puppetlabs-stdlib:
+      repo: https://github.com/puppetlabs/puppetlabs-stdlib
+    epel:
+      repo: https://github.com/stahnma/puppet-module-epel
   symlinks:
     docker: "#{source_dir}"

--- a/lib/facter/dockerd_binary.rb
+++ b/lib/facter/dockerd_binary.rb
@@ -1,0 +1,5 @@
+Facter.add(:dockerd_binary) do
+  setcode do
+    Facter::Core::Execution.which('dockerd')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
 RSpec::Matchers.define :require_string_for do |property|
   match do |type_class|
     config = {:name => 'name'}

--- a/spec/unit/dockerd_daemon_spec.rb
+++ b/spec/unit/dockerd_daemon_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'dockerd_binary fact' do
+
+  before :each do
+    Facter.clear
+  end
+
+  context 'when the dockerd binary is NOT present' do
+
+    before :each do
+      Facter.fact(:dockerd_binary).stubs(:value).returns(nil)
+    end
+
+    it 'return nil' do
+      expect(Facter.fact(:dockerd_binary).value).to be_nil
+    end
+  end
+
+  context 'when the dockerd binary is installed' do
+
+    before :each do
+      Facter.fact(:dockerd_binary).stubs(:value).returns('/some/path/to/dockerd')
+    end
+
+    it 'return the full path to the dockerd binary' do
+      expect(Facter.fact(:dockerd_binary).value).to eq('/some/path/to/dockerd')
+    end
+  end
+end

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,9 +2,9 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-<% unless @dockerd_daemon -%>
+<% unless @dockerd_binary -%>
 ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS
 <% end -%>
-ExecStart=/usr/bin/<%= @dockerd_daemon %> $OPTIONS \
+ExecStart=<%= @dockerd_binary %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,9 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
+<% unless @dockerd_daemon -%>
 ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+        $DOCKER_STORAGE_OPTIONS
+<% end -%>
+ExecStart=/usr/bin/<%= @dockerd_daemon %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -5,7 +5,14 @@ EnvironmentFile=-/etc/sysconfig/docker-network
 <% if @daemon_environment_files %><% @daemon_environment_files.each do |param| %>EnvironmentFile=-<%= param %>
 <% end %><% end -%>
 ExecStart=
+<% unless @dockerd_daemon -%>
 ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+      $DOCKER_STORAGE_OPTIONS \
+      $DOCKER_NETWORK_OPTIONS \
+      $BLOCK_REGISTRY \
+      $INSECURE_REGISTRY
+<% end -%>
+ExecStart=<%= @dockerd_daemon %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -5,14 +5,14 @@ EnvironmentFile=-/etc/sysconfig/docker-network
 <% if @daemon_environment_files %><% @daemon_environment_files.each do |param| %>EnvironmentFile=-<%= param %>
 <% end %><% end -%>
 ExecStart=
-<% unless @dockerd_daemon -%>
+<% unless @dockerd_binary -%>
 ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \
       $INSECURE_REGISTRY
 <% end -%>
-ExecStart=<%= @dockerd_daemon %> $OPTIONS \
+ExecStart=<%= @dockerd_binary %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
Using `docker daemon` has been deprecated since docker v1.13.  This means that if you are using a recent version of docker, the unit files for upstart and systemd call the deprecated binary that is not installed.  However, for people running older versions of docker, using `docker daemon` is correct.  In this pull request I am adding support for people using `dockerd`.  Here is a related issue https://github.com/garethr/garethr-docker/issues/701.