### PR TITLE
Add support for the proper --cpuset-cpus flag

### DIFF
--- a/lib/puppet/parser/functions/docker_run_flags.rb
+++ b/lib/puppet/parser/functions/docker_run_flags.rb
@@ -29,7 +29,7 @@ module Puppet::Parser::Functions
     cpusets = [opts['cpuset']].flatten.compact
     unless cpusets.empty?
       value = cpusets.join(',')
-      flags << "--cpuset=#{value}"
+      flags << "--cpuset-cpus=#{value}"
     end
 
     if opts['disable_network']

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -90,7 +90,7 @@ require 'spec_helper'
           else
             it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
             it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }
-            it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo_bar-baz/) }            
+            it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo_bar-baz/) }
           end
         end
       end
@@ -272,17 +272,17 @@ require 'spec_helper'
 
       context 'when passing a cpuset' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => '3'} }
-        it { should contain_file(initscript).with_content(/--cpuset=3/) }
+        it { should contain_file(initscript).with_content(/--cpuset-cpus=3/) }
       end
 
       context 'when passing a multiple cpu cpuset' do
         let(:params) { {'command' => 'command', 'image' => 'base', 'cpuset' => ['0', '3']} }
-        it { should contain_file(initscript).with_content(/--cpuset=0,3/) }
+        it { should contain_file(initscript).with_content(/--cpuset-cpus=0,3/) }
       end
 
       context 'when not passing a cpuset' do
         let(:params) { {'command' => 'command', 'image' => 'base'} }
-        it { should contain_file(initscript).without_content(/--cpuset=/) }
+        it { should contain_file(initscript).without_content(/--cpuset-cpus=/) }
       end
 
       context 'when passing a links option' do


### PR DESCRIPTION
The old one was removed in Docker 1.10.0 so systems would no longer properly boot after an upgrade. This restores the behaviour with the same API for the puppet type

Closes https://github.com/garethr/garethr-docker/issues/448