### PR TITLE
Set DOCKERBINARY in sysconfig to docker_command

### DIFF
--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -2,6 +2,7 @@
 # may be overwritten
 
 DOCKER="/usr/bin/<%= @docker_command %>"
+DOCKERBINARY="/usr/bin/<%= @docker_command %>"
 
 other_args="<% -%>
 <% if @root_dir %> -g <%= @root_dir %><% end -%>


### PR DESCRIPTION
This will allow compatibility with the centos packages, where:
/usr/bin/docker: a script sourcing /etc/sysconfig/docker

and docker-client and docker-client-latest packages install
/usr/bin/docker-current and /usr/bin/docker-latest, respectively.

Setting DOCKERBINARY in sysconfig defines which of the pkgs should be
used.