### PR TITLE
Compatibility with puppetlabs/apt 4.1.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,7 +136,7 @@ class docker::params {
       $package_cs_key_source = 'https://packages.docker.com/1.9/apt/gpg'
       $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
       $package_source_location = 'http://apt.dockerproject.org/repo'
-      $package_key_source = 'https://apt.dockerproject.org/gpg'
+      $package_key_source = 'https://pgp.mit.edu'
       $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -21,10 +21,14 @@ class docker::repos {
           location          => $location,
           release           => $docker::package_release,
           repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
           required_packages => 'debian-keyring debian-archive-keyring',
-          include_src       => false,
+          key               => {
+            'id'     => $package_key,
+            'server' => $key_source,
+          },
+          include           =>  {
+            'src' => false,
+          },
         }
         $url_split = split($location, '/')
         $repo_host = $url_split[2]

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -18,14 +18,14 @@ class docker::repos {
           $package_key = $docker::package_key
         }
         apt::source { 'docker':
-          location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
-          key               => {
+          location =>  $location,
+          release  => $docker::package_release,
+          repos    => $docker::package_repos,
+          key      => {
             'id'     => $package_key,
             'server' => $key_source,
           },
-          include           =>  {
+          include  => {
             'src' => false,
           },
         }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -21,7 +21,6 @@ class docker::repos {
           location          => $location,
           release           => $docker::package_release,
           repos             => $docker::package_repos,
-          required_packages => 'debian-keyring debian-archive-keyring',
           key               => {
             'id'     => $package_key,
             'server' => $key_source,

--- a/metadata.json
+++ b/metadata.json
@@ -31,7 +31,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/garethr/garethr-docker/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <= 3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":"<= 4.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 0.0.6"}
   ],
   "data_provider": null,
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.0"
+      "version_requirement": ">= 4.7.0"
     }
   ]
 }


### PR DESCRIPTION
These changes will make the calls to puppetlabs/apt compatible with 4.x+