### PR TITLE
Updates apt::source usage

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -17,14 +17,19 @@ class docker::repos {
           $key_source = $docker::package_key_source
           $package_key = $docker::package_key
         }
+        package {['debian-keyring', 'debian-archive-keyring']:
+          ensure => installed,
+        }
         apt::source { 'docker':
-          location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
-          key               => $package_key,
-          key_source        => $key_source,
-          required_packages => 'debian-keyring debian-archive-keyring',
-          include_src       => false,
+          location => $location,
+          release  => $docker::package_release,
+          repos    => $docker::package_repos,
+          key      => {
+            id     => $package_key,
+            source => $key_source,
+          },
+          require  => Package['debian-keyring', 'debian-archive-keyring'],
+          include  => { 'src' => false, },
         }
         $url_split = split($location, '/')
         $repo_host = $url_split[2]

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/garethr/garethr-docker/issues",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.1.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 1.8.0 <= 3.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 2.1.0"},
     {"name":"stahnma/epel","version_requirement":">= 0.0.6"}
   ],
   "data_provider": null,


### PR DESCRIPTION
The use of key_source in apt::source is deprecated since puppetlabs/apt
version 2.1.1 (at least) and removed in version 4.0.0.