### PR TITLE
Add support for docker-ce

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,10 @@
 #   Whether or not to use the CS (Commercial Support) Docker packages.
 #   Defaults to false.
 #
+# [*docker_ce*]
+#   Whether or not to use the CE (Community Edition) Docker packages.
+#   Defaults to false.
+#
 # [*tcp_bind*]
 #   The tcp socket to bind to in the format
 #   tcp://127.0.0.1:4243
@@ -287,6 +291,10 @@
 #   Specify custom package name
 #   Default is set on a per system basis in docker::params
 #
+# [*package_ce_name*]
+#   Specify custom package name for docker CE
+#   Default is set on a per system basis in docker::params
+#
 # [*service_name*]
 #   Specify custom service name
 #   Default is set on a per system basis in docker::params
@@ -351,6 +359,10 @@ class docker(
   $docker_cs                         = $docker::params::docker_cs,
   $package_cs_source_location        = $docker::params::package_cs_source_location,
   $package_cs_key_source             = $docker::params::package_cs_key_source,
+  $docker_ce                         = $docker::params::docker_ce,
+  $package_ce_source_location        = $docker::params::package_ce_source_location,
+  $package_ce_key_source             = $docker::params::package_ce_key_source,
+  $package_ce_key                    = $docker::params::package_ce_key,
   $tcp_bind                          = $docker::params::tcp_bind,
   $tls_enable                        = $docker::params::tls_enable,
   $tls_verify                        = $docker::params::tls_verify,
@@ -376,7 +388,9 @@ class docker(
   $apt_source_pin_level              = $docker::params::apt_source_pin_level,
   $package_source_location           = $docker::params::package_source_location,
   $package_release                   = $docker::params::package_release,
+  $package_ce_release                = $docker::params::package_ce_release,
   $package_repos                     = $docker::params::package_repos,
+  $package_ce_repos                  = $docker::params::package_ce_repos,
   $package_key                       = $docker::params::package_key,
   $package_key_source                = $docker::params::package_key_source,
   $service_state                     = $docker::params::service_state,
@@ -413,8 +427,10 @@ class docker(
   $package_source                    = $docker::params::package_source,
   $manage_epel                       = $docker::params::manage_epel,
   $package_name                      = $docker::params::package_name,
+  $package_ce_name                   = $docker::params::package_ce_name,
   $service_name                      = $docker::params::service_name,
   $docker_command                    = $docker::params::docker_command,
+  $docker_ce_command                 = $docker::params::docker_ce_command,
   $daemon_subcommand                 = $docker::params::daemon_subcommand,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,
@@ -448,6 +464,7 @@ class docker(
   validate_bool($manage_kernel)
   validate_bool($manage_package)
   validate_bool($docker_cs)
+  validate_bool($docker_ce)
   validate_bool($manage_service)
   validate_array($docker_users)
   validate_array($daemon_environment_files)
@@ -463,6 +480,10 @@ class docker(
   validate_string($fixed_cidr)
   validate_string($default_gateway)
   validate_string($bip)
+
+  if ($docker_cs) and ($docker_ce) {
+    fail('You could enable just one of Commercial or Community packages')
+  }
 
   if ($default_gateway) and (!$bridge) {
     fail('You must provide the $bridge parameter.')

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -103,9 +103,14 @@ class docker::install {
       }))
 
     } else {
+      $pkg_name = $docker::docker_ce ? {
+        true    => $docker::package_ce_name,
+        default => $docker::package_name,
+      }
+
       ensure_resource('package', 'docker', merge($docker_hash, {
         ensure => $ensure,
-        name   => $docker::package_name,
+        name   => $pkg_name,
       }))
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class docker::params {
   $version                           = undef
   $ensure                            = present
   $docker_cs                         = false
+  $docker_ce                         = false
   $tcp_bind                          = undef
   $tls_enable                        = false
   $tls_verify                        = true
@@ -57,8 +58,10 @@ class docker::params {
   $package_source                    = undef
   $manage_kernel                     = true
   $package_name_default              = 'docker-engine'
+  $package_name_ce_default           = 'docker-ce'
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
+  $docker_ce_command_default         = 'dockerd'
   $docker_group_default              = 'docker'
   $daemon_subcommand                 = 'daemon'
   $storage_devs                      = undef
@@ -80,6 +83,7 @@ class docker::params {
       case $::operatingsystem {
         'Ubuntu' : {
           $package_release = "ubuntu-${::lsbdistcodename}"
+          $package_ce_release = $facts['os']['distro']['codename']
           if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
             $service_provider        = 'systemd'
             $storage_config          = '/etc/default/docker-storage'
@@ -96,9 +100,12 @@ class docker::params {
             $service_hasrestart      = false
             $storage_config          = undef
           }
+          $package_ce_source_location = "https://download.docker.com/linux/ubuntu"
+          $package_ce_key_source = "https://download.docker.com/linux/ubuntu/gpg"
         }
         default: {
           $package_release = "debian-${::lsbdistcodename}"
+          $package_ce_release = $facts['os']['distro']['codename']
           if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
             $service_provider           = 'systemd'
             $storage_config             = '/etc/default/docker-storage'
@@ -115,15 +122,20 @@ class docker::params {
             $service_hasstatus          = undef
             $service_hasrestart         = undef
           }
+          $package_ce_source_location = "https://download.docker.com/linux/debian"
+          $package_ce_key_source = "https://download.docker.com/linux/debian/gpg"
         }
       }
 
       $manage_epel = false
       $package_name = $package_name_default
+      $package_ce_name = $package_name_ce_default
       $service_name = $service_name_default
       $docker_command = $docker_command_default
+      $docker_ce_command = $docker_ce_command_default
       $docker_group = $docker_group_default
       $package_repos = 'main'
+      $package_ce_repos = 'stable'
       $use_upstream_package_source = true
       $pin_upstream_package_source = true
       $apt_source_pin_level = 10
@@ -135,6 +147,7 @@ class docker::params {
       $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
       $package_cs_key_source = 'https://packages.docker.com/1.9/apt/gpg'
       $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
+      $package_ce_key = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
       $package_source_location = 'http://apt.dockerproject.org/repo'
       $package_key_source = 'https://apt.dockerproject.org/gpg'
       $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
@@ -185,6 +198,7 @@ class docker::params {
       }
       $package_cs_source_location = "https://packages.docker.com/1.9/yum/repo/main/centos/${::operatingsystemmajrelease}"
       $package_cs_key_source = 'https://packages.docker.com/1.9/yum/gpg'
+      $package_ce_source_location = 'https://download.docker.com/linux/centos/docker-ce.repo'
       $package_key = undef
       $package_cs_ke = undef
       $package_repos = undef

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -12,15 +12,29 @@ class docker::repos {
           $location = $docker::package_cs_source_location
           $key_source = $docker::package_cs_key_source
           $package_key = $docker::package_cs_key
+        } elsif ($docker::docker_ce) {
+          $location = $docker::package_ce_source_location
+          $key_source = $docker::package_ce_key_source
+          $package_key = $docker::package_ce_key
         } else {
           $location = $docker::package_source_location
           $key_source = $docker::package_key_source
           $package_key = $docker::package_key
         }
+        case $docker::docker_ce {
+          true: {
+            $release = $docker::package_ce_release
+            $repos = $docker::package_ce_repos
+          }
+          default: {
+            $release = $docker::package_release
+            $repos = $docker::package_repos
+          }
+        }
         apt::source { 'docker':
           location          => $location,
-          release           => $docker::package_release,
-          repos             => $docker::package_repos,
+          release           => $release,
+          repos             => $repos,
           key               => $package_key,
           key_source        => $key_source,
           required_packages => 'debian-keyring debian-archive-keyring',
@@ -53,6 +67,9 @@ class docker::repos {
         if ($docker::docker_cs) {
           $baseurl = $docker::package_cs_source_location
           $gpgkey = $docker::package_cs_key_source
+        } elsif ($docker::docker_ce) {
+          $baseurl = $docker::package_ce_source_location
+          $gpgkey = undef
         } else {
           $baseurl = $docker::package_source_location
           $gpgkey = $docker::package_key_source

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,6 +38,8 @@
 #
 class docker::service (
   $docker_command                    = $docker::docker_command,
+  $docker_ce_command                 = $docker::docker_ce_command,
+  $docker_ce                         = $docker::docker_ce,
   $service_name                      = $docker::service_name,
   $daemon_subcommand                 = $docker::daemon_subcommand,
   $tcp_bind                          = $docker::tcp_bind,

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,9 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
+<%- if @docker_ce -%>
+ExecStart=/usr/bin/<%= @docker_ce_command %> $OPTIONS \
+<%- else -%>
 ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+<%- end -%>
         $DOCKER_STORAGE_OPTIONS


### PR DESCRIPTION
Adds parameters to enable the installation of docker-ce instead of
docker. It's done in a similary way thatn docker_cs support.
I don't deeply tested in other platforms but Ubuntu (local tests didn't work for me) so maybe there is need to do it (I could try them if you want to merge it).