### PR TITLE
include_src deprecated in next major release. 

### DIFF
--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -24,7 +24,7 @@ class docker::repos {
           key               => $package_key,
           key_source        => $key_source,
           required_packages => 'debian-keyring debian-archive-keyring',
-          include_src       => false,
+          include           => { 'src' => false },
         }
         $url_split = split($location, '/')
         $repo_host = $url_split[2]


### PR DESCRIPTION
$include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead