### PR TITLE
Remove unnecessary refreshonly flag from remove container exec

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -313,7 +313,6 @@ define docker::run(
         exec {
           "remove container ${service_prefix}${sanitised_title}":
             command     => "${docker_command} rm -v ${sanitised_title}",
-            refreshonly => true,
             onlyif      => "${docker_command} ps --no-trunc -a --format='table {{.Names}}' | grep '^${sanitised_title}$'",
             path        => ['/bin', '/usr/bin'],
             environment => 'HOME=/root',


### PR DESCRIPTION
The refreshonly flag tells puppet to only execute the command of an exec resource when something has "changed". But there is no notify that tells this exec that something has changed so with the refreshonly flag the command will be never executed.