### PR TITLE
added unless to registry

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -34,6 +34,7 @@ define docker::registry(
   $password    = undef,
   $email       = undef,
   $local_user  = 'root',
+  $unless      = undef,
 ) {
   include docker::params
 
@@ -67,6 +68,7 @@ define docker::registry(
     cwd         => '/root',
     path        => ['/bin', '/usr/bin'],
     timeout     => 0,
+    unless      => $unless,
   }
 
 }


### PR DESCRIPTION
Simplest workaround to #678 
Since the docker registry is an exec, pass in an unless parameter (named as such) for preventing succeeding execs