### PR TITLE
Minor change - Uncommented TMPDIR for rhel 7 machines

### DIFF
--- a/templates/etc/sysconfig/docker.systemd.erb
+++ b/templates/etc/sysconfig/docker.systemd.erb
@@ -29,5 +29,5 @@ OPTIONS="<% if @root_dir %> -g <%= @root_dir %><% end -%>
   https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>no_proxy='<%= @no_proxy %>'<% end %>
 # This is also a handy place to tweak where Docker's temporary files go.
-# TMPDIR="<%= @tmp_dir %>"
+TMPDIR="<%= @tmp_dir %>"
 <% if @shell_values %><% @shell_values_array.each do |param| %> <%= param %><% end %><% end -%>


### PR DESCRIPTION
This is causing issues as we (and i assume a majority of others) set `noexec` on `/tmp` and it's causing docker to produce this error.

```docker-compose: error while loading shared libraries: libz.so.1: failed to map segment from shared object: Operation not permitted```

