### PR TITLE
 Remove initscript on Docker::Run ensure => absent

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -317,6 +317,10 @@ define docker::run(
             timeout     => 0
         }
 
+        file { $initscript:
+          ensure  => absent,
+        }
+
     }
     else {
       file { $initscript:

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -90,7 +90,7 @@ require 'spec_helper'
           else
             it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
             it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }
-            it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo_bar-baz/) }            
+            it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo_bar-baz/) }
           end
         end
       end
@@ -706,6 +706,7 @@ require 'spec_helper'
         it { should compile.with_all_deps }
         it { should contain_service('docker-sample').with_ensure(false) }
         it { should contain_exec("remove container docker-sample").with_command('docker rm -v sample') }
+        it { should contain_file(initscript).with_ensure('absent') }
       end
 
     end


### PR DESCRIPTION
When setting ensure on a Docker::run resource to absent the initscript the initscript is not removed. 

This patch ensures that the initscript is properly removed.

