### PR TITLE
Support for docker-ce and docker-ee

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Puppet module for installing, configuring and managing
-[Docker](https://github.com/docker/docker) from the [official repository](https://docs.docker.com/installation/) or alternatively from [EPEL on RedHat](https://docs.docker.io/en/latest/installation/rhel/) based distributions.
+[Docker](https://github.com/docker/docker) from the [official repository](https://docs.docker.com/engine/installation/)
 
 [![Puppet
 Forge](https://img.shields.io/puppetforge/v/garethr/docker.svg)](https://forge.puppetlabs.com/garethr/docker) [![Build
@@ -19,6 +19,7 @@ This module is currently tested on:
 * Ubuntu 14.04
 * Centos 7.0
 * Centos 6.6
+
 
 It may work on other distros and additional operating systems will be
 supported in the future. It's definitely been used with the following
@@ -53,7 +54,7 @@ include 'docker'
 ```
 
 By default this sets up the docker hosted repository if necessary for your OS
-and installs the docker package and on Ubuntu, any required Kernel extensions.
+and installs the docker-ce package and on Ubuntu, any required Kernel extensions.
 
 If you don't want this module to mess about with your Kernel then you can disable
 this feature like so. It is only enabled (and supported) by default on Ubuntu:
@@ -74,29 +75,21 @@ class { 'docker':
 }
 ```
 
-Docker recently [launched new official
-repositories](https://blog.docker.com/2015/07/new-apt-and-yum-repos/#comment-247448)
-which are now the default for the module from version 5. If you want to
-stick with the old repositories you can do so with the following:
-
-```puppet
-class { 'docker':
-  package_name => 'lxc-docker',
-  package_source_location => 'https://get.docker.com/ubuntu',
-  package_key_source => 'https://get.docker.com/gpg',
-  package_key => '36A1D7869245C8950F966E92D8576A8BA88D21E',
-  package_release => 'docker',
-}
-```
-
-Docker also provide a [commercially
-supported](https://docs.docker.com/docker-trusted-registry/install/install-csengine/)
-version of the Docker Engine, called Docker CS, available from a separate repository.
-This can be installed with the module using the following:
+Docker recently split docker into a Community Edition (docker-ce) and
+a commercially supported Enterprise Edition (docker-ee). This module
+supports installing the CE version out of the box. You can also use
+the commercial version by setting the docker_cs flag to true. However
+you also need to set package_source_location, package_release,
+package_repos, package_key and package_key_source must be set
+accordingly to the OS requirements.
 
 ```puppet
 class { 'docker':
   docker_cs => true,
+  package_source_location => '<DOCKER-EE-URL>',
+  package_key_source => '<DOCKER-EE-URL>/gpg',
+  package_key => '<DOCKER-EE-GPG-KEY-FINGERPRINT-FOR-THE-OS>
+  package_release => 'stable-<YY.MM>
 }
 ```
 
@@ -420,7 +413,7 @@ file.
 Before using the docker_compose type make sure the docker-compose utility is installed:
 
 ```puppet
-class {'docker::compose': 
+class {'docker::compose':
   ensure => present,
 }
 ```
@@ -475,10 +468,10 @@ For a swarm manager:
 docker::swarm {'cluster_manager':
   init           => true,
   advertise_addr => '192.168.1.1',
-  listen_addr    => '192.168.1.1',  
-} 
+  listen_addr    => '192.168.1.1',
+}
 ```
-In the above example we have configured a swarm manager with ```init => true``` then set the ```advertise_addr``` and ```listen_addr```. Both the ```advertise_addr``` and ```listen_addr``` are set for the cluster communications between nodes. Please note the ```advertise_addr``` and ```listen_addr``` must be set for a multihomed server. For more advance flags to configure raft snapshots etc please read the readme at the top of the ```docker::swarm``` class.  
+In the above example we have configured a swarm manager with ```init => true``` then set the ```advertise_addr``` and ```listen_addr```. Both the ```advertise_addr``` and ```listen_addr``` are set for the cluster communications between nodes. Please note the ```advertise_addr``` and ```listen_addr``` must be set for a multihomed server. For more advance flags to configure raft snapshots etc please read the readme at the top of the ```docker::swarm``` class.
 
 For a swarm worker:
 ```puppet
@@ -488,7 +481,7 @@ advertise_addr => '192.168.1.2',
 listen_addr    => '192.168.1.2,
 manager_ip     => '192.168.1.1',
 token          => 'SWMTKN-1-2lw8bnr57qsu74d6iq2q1wr2wq2i334g7425dfr3zucimvh4bl-2vwn6gysbdj605l37c61iixie'
-} 
+}
 ```
 
 In this example we have joined a node to the cluster using ```join => true```. For a worker node or second manager you need to pass a current managers ip address ```manager_ip => '192.168.1.1'```
@@ -507,18 +500,18 @@ To configure a service with Puppet code please see the following examples
 To create a service
 ```puppet
 docker::services {'redis':
-    create => true,   
+    create => true,
     service_name => 'redis',
     image => 'redis:latest',
     publish => '6379:639',
-    replicas => '5', 
+    replicas => '5',
     extra_params => ['--update-delay 1m', '--restart-window 30s']
   }
 ```
 In this example we are creating a service called `redis`, as it is a new service we have set `create => true`. The `service_name` resource is the name which Docker knows the service as. The `image` resource is the image you want to base the service off, `publish` is the ports that want exposed to the outside world for the service to be consumed, `replicas` sets the amount of tasks (containers) that you want running in the service, `extra_params` allows you to configure any of the other flags that Docker gives you when you create a service for more info see `docker service create --help`
 
 To update the service
-```puppet 
+```puppet
 docker::services {'redis_update':
   create => false,
   update => true,
@@ -534,7 +527,7 @@ docker::services {'redis_scale':
   create => false,
   scale => true,
   service_name => 'redis',
-  replicas => '10', 
+  replicas => '10',
 }
 ```
 In this example we have used the command `docker service scale` with Puppet code. We have taken our service `redis` set the `create => false` and `scale => true` When using scale you have to declare your `service_name` then the number of replicas that you want. In this example we are going to scale to `10`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -311,8 +311,8 @@
 #   Specify a custom docker command name
 #   Default is set on a per system basis in docker::params
 #
-# [*daemon_subcommand*]
-#  Specify a subcommand/flag for running docker as daemon
+# [*docker_daemon_command*]
+#  Specify a command for running docker as daemon
 #  Default is set on a per system basis in docker::params
 #
 # [*docker_users*]
@@ -430,7 +430,7 @@ class docker(
   $manage_epel                       = $docker::params::manage_epel,
   $service_name                      = $docker::params::service_name,
   $docker_command                    = $docker::params::docker_command,
-  $daemon_subcommand                 = $docker::params::daemon_subcommand,
+  $docker_daemon_command             = $docker::params::docker_daemon_command,
   $docker_users                      = [],
   $docker_group                      = $docker::params::docker_group,
   $daemon_environment_files          = [],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,8 +16,16 @@
 #   An array of additional packages that need to be installed to support
 #   docker. Defaults change depending on the operating system.
 #
+# [*purge_packages*]
+#   An array of packages that need to be removed not to conflict with
+#   docker. Set to undef to avoud purging packages.
+#   Defaults to old docker packages, fx. docker.io and docker-engine
+#
 # [*docker_cs*]
 #   Whether or not to use the CS (Commercial Support) Docker packages.
+#   If commercial support packages are used the parameters
+#   package_source_location, package_release, package_repos, package_key
+#   and package_key_source must be set accordingly to the OS requirements.
 #   Defaults to false.
 #
 # [*tcp_bind*]
@@ -173,6 +181,14 @@
 # [*package_source_location*]
 #   If you're using an upstream package source, what is it's
 #   location. Defaults to http://get.docker.com/ubuntu on Debian
+#
+# [*package_repos*]
+#   Which package repository to use.
+#   For CE: edge, stable, test
+#           Defaults to stable
+#   For EE: fx. stable-17.09
+#           Defaults to undefined. This parameter must be set explictly if
+#           using commercially suported Docker (ie docker_cs flag is true)
 #
 # [*service_state*]
 #   Whether you want to docker daemon to start up
@@ -348,9 +364,8 @@ class docker(
   $version                           = $docker::params::version,
   $ensure                            = $docker::params::ensure,
   $prerequired_packages              = $docker::params::prerequired_packages,
+  $purge_packages                    = $docker::params::purge_packages,
   $docker_cs                         = $docker::params::docker_cs,
-  $package_cs_source_location        = $docker::params::package_cs_source_location,
-  $package_cs_key_source             = $docker::params::package_cs_key_source,
   $tcp_bind                          = $docker::params::tcp_bind,
   $tls_enable                        = $docker::params::tls_enable,
   $tls_verify                        = $docker::params::tls_verify,
@@ -379,6 +394,7 @@ class docker(
   $package_repos                     = $docker::params::package_repos,
   $package_key                       = $docker::params::package_key,
   $package_key_source                = $docker::params::package_key_source,
+  $package_name                      = $docker::params::package_name,
   $service_state                     = $docker::params::service_state,
   $service_enable                    = $docker::params::service_enable,
   $manage_service                    = $docker::params::manage_service,
@@ -412,7 +428,6 @@ class docker(
   $manage_package                    = $docker::params::manage_package,
   $package_source                    = $docker::params::package_source,
   $manage_epel                       = $docker::params::manage_epel,
-  $package_name                      = $docker::params::package_name,
   $service_name                      = $docker::params::service_name,
   $docker_command                    = $docker::params::docker_command,
   $daemon_subcommand                 = $docker::params::daemon_subcommand,
@@ -448,6 +463,13 @@ class docker(
   validate_bool($manage_kernel)
   validate_bool($manage_package)
   validate_bool($docker_cs)
+  if ($package_repos and $use_upstream_package_source) {
+    if ($docker_cs) {
+      validate_re($package_repos, '^stable-\d{2}\.\d{2}$')
+    } else {
+      validate_re($package_repos, '^(stable|edge|test)$')
+    }
+  }
   validate_bool($manage_service)
   validate_array($docker_users)
   validate_array($daemon_environment_files)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,6 +17,12 @@ class docker::install {
     $ensure = $docker::ensure
   }
 
+  if ($docker::purge_packages) {
+    ensure_resource('package', $docker::purge_packages, {
+      ensure => absent,
+      before => Package['docker'],
+      })
+  }
   case $::osfamily {
     'Debian': {
       if $::operatingsystem == 'Ubuntu' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,8 @@ class docker::params {
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true
-  $package_name_default              = 'docker-engine'
+  $package_name_default              = 'docker-ce'
+  $package_name_cs_default           = 'docker-ee'
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
@@ -75,11 +76,11 @@ class docker::params {
   $compose_version                   = '1.9.0'
   $compose_install_path              = '/usr/local/bin'
 
+
   case $::osfamily {
     'Debian' : {
       case $::operatingsystem {
         'Ubuntu' : {
-          $package_release = "ubuntu-${::lsbdistcodename}"
           if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
             $service_provider        = 'systemd'
             $storage_config          = '/etc/default/docker-storage'
@@ -98,7 +99,6 @@ class docker::params {
           }
         }
         default: {
-          $package_release = "debian-${::lsbdistcodename}"
           if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
             $service_provider           = 'systemd'
             $storage_config             = '/etc/default/docker-storage'
@@ -119,11 +119,9 @@ class docker::params {
       }
 
       $manage_epel = false
-      $package_name = $package_name_default
       $service_name = $service_name_default
       $docker_command = $docker_command_default
       $docker_group = $docker_group_default
-      $package_repos = 'main'
       $use_upstream_package_source = true
       $pin_upstream_package_source = true
       $apt_source_pin_level = 10
@@ -132,12 +130,38 @@ class docker::params {
       $service_config = undef
       $storage_setup_file = undef
 
-      $package_cs_source_location = 'http://packages.docker.com/1.9/apt/repo'
-      $package_cs_key_source = 'https://packages.docker.com/1.9/apt/gpg'
-      $package_cs_key = '0xee6d536cf7dc86e2d7d56f59a178ac6c6238f52e'
-      $package_source_location = 'http://apt.dockerproject.org/repo'
-      $package_key_source = 'https://apt.dockerproject.org/gpg'
-      $package_key = '58118E89F3A912897C070ADBF76221572C52609D'
+      $package_release = $::lsbdistcodename
+      $package_os = downcase($::operatingsystem)
+
+      $package_name = $docker_cs ? {
+        true    => $package_name_cs_default,
+        default => $package_name_default
+      }
+
+      # package_repos:
+      # For CE: edge, stable, test.
+      # For EE, fx stable-17.09. Must be set explicitly.
+      $package_repos = $docker_cs ? {
+        true    => undef,
+        default => 'stable'
+      }
+
+      $package_source_location =  $docker_cs ? {
+        true    => undef,
+        default => "https://download.docker.com/linux/${package_os}"
+      }
+
+      $package_key_source = $docker_cs ? {
+        true    => undef,
+        default => "${package_source_location}/gpg"
+      }
+
+      $package_key =  $docker_cs ? {
+        true => 'DD911E995A64A202E85907D6BC14F10B6D085F96',
+        default => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+      }
+
+      $purge_packages = ['docker-engine', 'docker.io']
 
       if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or
         ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') >= 0) {
@@ -165,29 +189,52 @@ class docker::params {
       }
 
       if (versioncmp($::operatingsystemrelease, '7.0') < 0) and $::operatingsystem != 'Amazon' {
-        $package_name = 'docker-io'
         $use_upstream_package_source = false
         $manage_epel = true
       } elsif $::operatingsystem == 'Amazon' {
-        $package_name = 'docker'
         $use_upstream_package_source = false
         $manage_epel = false
       } else {
-        $package_name = $package_name_default
         $use_upstream_package_source = true
         $manage_epel = false
       }
-      $package_key_source = 'https://yum.dockerproject.org/gpg'
-      if $::operatingsystem == 'Fedora' {
-        $package_source_location = "https://yum.dockerproject.org/repo/main/fedora/${::operatingsystemmajrelease}"
-      } else {
-        $package_source_location = "https://yum.dockerproject.org/repo/main/centos/${::operatingsystemmajrelease}"
+
+      $package_os = downcase($::operatingsystem)
+      case $docker_cs {
+        true : {
+          $package_repos = undef
+          $package_source_location = undef
+          $package_key = undef
+          $package_key_source = undef
+          $purge_packages = ['docker-common', 'docker-selinux', 'docker-engine-selinux', 'docker-engine','docker-ce']
+        }
+        default : {
+          $package_repos = 'stable'
+          $package_source_location = $::operatingsystem ? {
+            /(CentOS|Fedora)/ => "https://download.docker.com/linux/${package_os}/${::operatingsystemmajrelease}/${::architecture}/${package_repos}",
+            default           => undef
+          }
+          $package_key =  $::operatingsystem ? {
+            /(CentOS|Fedora)/ => '060A61C51B558A7F742B77AAC52FEB6B621E9F35',
+            default           => undef,
+          }
+          $package_key_source = $::operatingsystem ? {
+            /(CentOS|Fedora)/ => "https://download.docker.com/linux/${package_os}/gpg",
+            default => undef
+          }
+          $purge_packages = $::operatingsystem ? {
+            'CentOS' => ['docker-common', 'docker-selinux', 'docker-engine'],
+            'Fedora' => ['docker-common', 'docker-selinux', 'docker-engine', 'docker-engine-selinux'],
+            default  => ['docker-common', 'docker-selinux', 'docker-engine', 'docker-engine-selinux'],
+          }
+        }
       }
-      $package_cs_source_location = "https://packages.docker.com/1.9/yum/repo/main/centos/${::operatingsystemmajrelease}"
-      $package_cs_key_source = 'https://packages.docker.com/1.9/yum/gpg'
-      $package_key = undef
-      $package_cs_ke = undef
-      $package_repos = undef
+
+      $package_name = $docker_cs ? {
+        true    => $package_name_cs_default,
+        default => $package_name_default,
+      }
+
       $package_release = undef
       $pin_upstream_package_source = undef
       $apt_source_pin_level = undef
@@ -240,15 +287,14 @@ class docker::params {
 
       $manage_epel = false
       $docker_group = $docker_group_default
+      $package_name = undef
       $package_key_source = undef
       $package_source_location = undef
       $package_key = undef
       $package_repos = undef
       $package_release = undef
+      $purge_packages = undef
       $use_upstream_package_source = false
-      $package_cs_source_location = undef
-      $package_cs_key_source = undef
-      $package_name = 'docker'
       $service_name = $service_name_default
       $docker_command = $docker_command_default
       $detach_service_in_init = false
@@ -273,9 +319,8 @@ class docker::params {
       $package_key = undef
       $package_repos = undef
       $package_release = undef
+      $purge_packages = undef
       $use_upstream_package_source = false
-      $package_cs_source_location = undef
-      $package_cs_key_source = undef
       $package_name = 'app-emulation/docker'
       $service_name = $service_name_default
       $docker_command = $docker_command_default
@@ -299,10 +344,9 @@ class docker::params {
       $package_key_source = undef
       $package_source_location = undef
       $package_key = undef
-      $package_cs_source_location = undef
-      $package_cs_key_source = undef
       $package_repos = undef
       $package_release = undef
+      $purge_packages = undef
       $use_upstream_package_source = true
       $service_overrides_template = undef
       $service_hasstatus  = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class docker::params {
   $service_name_default              = 'docker'
   $docker_command_default            = 'docker'
   $docker_group_default              = 'docker'
-  $daemon_subcommand                 = 'daemon'
+  $docker_daemon_command             = 'dockerd'
   $storage_devs                      = undef
   $storage_vg                        = undef
   $storage_root_size                 = undef

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -8,15 +8,10 @@ class docker::repos {
   case $::osfamily {
     'Debian': {
       if ($docker::use_upstream_package_source) {
-        if ($docker::docker_cs) {
-          $location = $docker::package_cs_source_location
-          $key_source = $docker::package_cs_key_source
-          $package_key = $docker::package_cs_key
-        } else {
-          $location = $docker::package_source_location
-          $key_source = $docker::package_key_source
-          $package_key = $docker::package_key
-        }
+        $location = $docker::package_source_location
+        $key_source = $docker::package_key_source
+        $package_key = $docker::package_key
+
         apt::source { 'docker':
           location          => $location,
           release           => $docker::package_release,
@@ -50,13 +45,9 @@ class docker::repos {
     }
     'RedHat': {
       if $docker::manage_package {
-        if ($docker::docker_cs) {
-          $baseurl = $docker::package_cs_source_location
-          $gpgkey = $docker::package_cs_key_source
-        } else {
-          $baseurl = $docker::package_source_location
-          $gpgkey = $docker::package_key_source
-        }
+        $baseurl = $docker::package_source_location
+        $gpgkey = $docker::package_key_source
+
         if ($docker::use_upstream_package_source) {
           yumrepo { 'docker':
             descr    => 'Docker',

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -317,6 +317,10 @@ define docker::run(
             timeout     => 0
         }
 
+        file { $initscript:
+          ensure  => absent,
+        }
+
     }
     else {
       file { $initscript:

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -39,7 +39,7 @@
 class docker::service (
   $docker_command                    = $docker::docker_command,
   $service_name                      = $docker::service_name,
-  $daemon_subcommand                 = $docker::daemon_subcommand,
+  $docker_daemon_command             = $docker::docker_daemon_command,
   $tcp_bind                          = $docker::tcp_bind,
   $ip_forward                        = $docker::ip_forward,
   $iptables                          = $docker::iptables,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -1049,4 +1049,100 @@ describe 'docker', :type => :class do
     end
   end
 
+  context 'with options to install docker-ee on Ubuntu' do
+    let (:facts) {{
+          :osfamily               => 'Debian',
+          :operatingsystem        => 'Ubuntu',
+          :lsbdistid              => 'Ubuntu',
+          :lsbdistcodename        => 'trusty',
+          :kernelrelease          => '3.13.0-129-generic',
+          :operatingsystemrelease => '14.04',
+          :operatingsystemmajrelease => '14',
+    }}
+
+    let(:params) {{
+      'docker_cs'                => true,
+      'package_source_location'  => 'https://download.docker-ee.com/linux/ubuntu',
+      'package_release'          => 'trusty',
+      'package_repos'            => 'stable-17.09',
+      'package_key'              => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
+      'package_key_source'       => 'https://download.docker-ee.com/linux/ubuntu/gpg',
+      'package_name'             => 'docker-ee',
+    }}
+      it { should contain_apt__source('docker').with_location("https://download.docker-ee.com/linux/ubuntu") }
+      it { should contain_package('docker').with_name('docker-ee').with_ensure('present') }
+      it { should contain_apt__pin('docker').with_origin('download.docker-ee.com') }
+      it { should contain_package('docker').with_install_options(nil) }
+  end
+
+  context 'with options to install docker-ee on Debian' do
+    let (:facts) {{
+          :osfamily               => 'Debian',
+          :operatingsystem        => 'Debian',
+          :lsbdistid              => 'Debian',
+          :lsbdistcodename        => 'wheezy',
+          :kernelrelease          => '3.13.0-129-generic',
+          :operatingsystemrelease => '8.0',
+          :operatingsystemmajrelease => '8',
+    }}
+
+    let(:params) {{
+      'docker_cs'                => true,
+      'package_source_location'  => 'https://download.docker-ee.com/linux/debian',
+      'package_release'          => 'wheezy',
+      'package_repos'            => 'stable-17.09',
+      'package_key'              => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
+      'package_key_source'       => 'https://download.docker-ee.com/linux/debian/gpg',
+      'package_name'             => 'docker-ee',
+    }}
+      it { should contain_apt__source('docker').with_location("https://download.docker-ee.com/linux/debian") }
+      it { should contain_package('docker').with_name('docker-ee').with_ensure('present') }
+      it { should contain_apt__pin('docker').with_origin('download.docker-ee.com') }
+      it { should contain_package('docker').with_install_options(nil) }
+  end
+
+  context 'with options to install docker-ee on CentOS' do
+    let (:facts) {{
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'CentOS',
+          :kernelversion          => '3.10.0',
+          :operatingsystemrelease => '7.4',
+          :operatingsystemmajrelease => '7',
+          :architecture           => 'x64_64',
+    }}
+
+    let(:params) {{
+      'docker_cs'                => true,
+      'package_source_location'  => 'https://download.docker-ee.com/linux/centos/7/x86_64/stable',
+      'package_repos'            => 'stable-17.09',
+      'package_key'              => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
+      'package_key_source'       => 'https://download.docker-ee.com/linux/debian/gpg',
+      'package_name'             => 'docker-ee',
+    }}
+      it { should contain_yumrepo('docker').with_baseurl("https://download.docker-ee.com/linux/centos/7/x86_64/stable") }
+      it { should contain_package('docker').with_name('docker-ee').with_ensure('present') }
+  end
+
+  context 'with options to install docker-ee on Fedora' do
+    let (:facts) {{
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'Fedora',
+          :kernelversion          => '3.10.0',
+          :operatingsystemrelease => '26',
+          :operatingsystemmajrelease => '26',
+          :architecture           => 'x64_64',
+    }}
+
+    let(:params) {{
+      'docker_cs'                => true,
+      'package_source_location'  => 'https://download.docker-ee.com/linux/fedora/26/x86_64/stable',
+      'package_repos'            => 'stable-17.09',
+      'package_key'              => '9DC858229FC7DD38854AE2D88D81803C0EBFCD88',
+      'package_key_source'       => 'https://download.docker-ee.com/linux/debian/gpg',
+      'package_name'             => 'docker-ee',
+    }}
+      it { should contain_yumrepo('docker').with_baseurl("https://download.docker-ee.com/linux/fedora/26/x86_64/stable") }
+      it { should contain_package('docker').with_name('docker-ee').with_ensure('present') }
+  end
+
 end

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -21,6 +21,9 @@ describe 'docker', :type => :class do
         context 'It should include default prerequired_packages' do
           it { should contain_package('cgroupfs-mount').with_ensure('present') }
         end
+
+        it { should contain_apt__source('docker').with_location("https://download.docker.com/linux/debian") }
+
       end
 
       if osfamily == 'Ubuntu'
@@ -43,28 +46,30 @@ describe 'docker', :type => :class do
           it { should contain_package('cgroup-lite').with_ensure('present') }
           it { should contain_package('apparmor').with_ensure('present') }
         end
+
+        it { should contain_apt__source('docker').with_location("https://download.docker.com/linux/ubuntu") }
+
       end
 
       if osfamily == 'Ubuntu' or osfamily == 'Debian'
 
         it { should contain_class('apt') }
-        it { should contain_package('docker').with_name('docker-engine').with_ensure('present') }
-        it { should contain_apt__source('docker').with_location('http://apt.dockerproject.org/repo') }
-        it { should contain_apt__pin('docker').with_origin('apt.dockerproject.org') }
+        it { should contain_package('docker').with_name('docker-ce').with_ensure('present') }
+        it { should contain_apt__pin('docker').with_origin('download.docker.com') }
         it { should contain_package('docker').with_install_options(nil) }
 
         it { should contain_file('/etc/default/docker').without_content(/icc=/) }
 
         context 'with a custom version' do
           let(:params) { {'version' => '0.5.5' } }
-          it { should contain_package('docker').with_ensure('0.5.5').with_name('docker-engine') }
+          it { should contain_package('docker').with_ensure('0.5.5').with_name('docker-ce') }
         end
 
         context 'with no upstream package source' do
           let(:params) { {'use_upstream_package_source' => false } }
           it { should_not contain_apt__source('docker') }
           it { should_not contain_apt__pin('docker') }
-          it { should contain_package('docker').with_name('docker-engine') }
+          it { should contain_package('docker').with_name('docker-ce') }
         end
 
         context 'with no upstream package source' do
@@ -195,6 +200,7 @@ describe 'docker', :type => :class do
           :operatingsystemrelease => '6.5',
           :operatingsystemmajrelease => '7',
           :kernelversion => '2.6.32',
+          :architecture  => 'x86_64',
         } }
         service_config_file = '/etc/sysconfig/docker'
         storage_config_file = '/etc/sysconfig/docker-storage'
@@ -319,14 +325,14 @@ describe 'docker', :type => :class do
           let(:params) { {
             'manage_package'              => true,
             'use_upstream_package_source' => false,
-            'package_name'                => 'docker-engine',
-            'package_source'              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm'
+            'package_name'                => 'docker-ce',
+            'package_source'              => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
           } }
           it do
             should contain_package('docker').with(
               'ensure' => 'present',
-              'source' => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
-              'name'   => 'docker-engine'
+              'source' => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
+              'name'   => 'docker-ce'
             )
           end
         end
@@ -335,15 +341,15 @@ describe 'docker', :type => :class do
           let(:params) { {
             'manage_package'              => true,
             'use_upstream_package_source' => false,
-            'package_name'                => 'docker-engine',
-            'package_source'              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+            'package_name'                => 'docker-ce',
+            'package_source'              => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
             'repo_opt'                    => '--enablerepo=rhel7-extras'
           } }
           it do
             should contain_package('docker').with(
               'ensure'          => 'present',
-              'source'          => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
-              'name'            => 'docker-engine',
+              'source'          => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
+              'name'            => 'docker-ce',
               'install_options' => '--enablerepo=rhel7-extras'
             )
           end
@@ -353,14 +359,14 @@ describe 'docker', :type => :class do
           let(:params) { {
             'manage_package'              => true,
             'use_upstream_package_source' => false,
-            'package_name'                => 'docker-engine',
-            'package_source'              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm'
+            'package_name'                => 'docker-ce',
+            'package_source'              => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
           } }
           it do
             should contain_package('docker').with(
               'ensure'          => 'present',
-              'source'          => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
-              'name'            => 'docker-engine',
+              'source'          => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
+              'name'            => 'docker-ce',
               'install_options' => /--enablerepo/
             )
           end
@@ -370,15 +376,15 @@ describe 'docker', :type => :class do
           let(:params) { {
             'manage_package'              => true,
             'use_upstream_package_source' => false,
-            'package_name'                => 'docker-engine',
-            'package_source'              => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
+            'package_name'                => 'docker-ce',
+            'package_source'              => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
             'repo_opt'                    => ''
           } }
           it do
             should contain_package('docker').with(
               'ensure'          => 'present',
-              'source'          => 'https://get.docker.com/rpm/1.7.0/centos-6/RPMS/x86_64/docker-engine-1.7.0-1.el6.x86_64.rpm',
-              'name'            => 'docker-engine',
+              'source'          => 'https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-17.09.0.ce-1.el7.centos.x86_64.rpm',
+              'name'            => 'docker-ce',
               'install_options' => nil
             )
           end
@@ -754,7 +760,7 @@ describe 'docker', :type => :class do
       let(:params) { {'use_upstream_package_source' => false } }
       it { should_not contain_apt__source('docker') }
       it { should_not contain_apt__pin('docker') }
-      it { should contain_package('docker').with_name('docker-engine') }
+      it { should contain_package('docker').with_name('docker-ce') }
     end
   end
 
@@ -765,6 +771,7 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '6.5',
       :operatingsystemmajrelease => '6',
       :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
 
     it { should contain_class('epel') }
@@ -775,7 +782,7 @@ describe 'docker', :type => :class do
       it { should_not contain_class('epel') }
     end
 
-    it { should contain_package('docker').with_name('docker-io').with_ensure('present') }
+    it { should contain_package('docker').with_name('docker-ce').with_ensure('present') }
     it { should_not contain_apt__source('docker') }
     it { should_not contain_package('linux-image-extra-3.8.0-29-generic') }
 
@@ -787,7 +794,8 @@ describe 'docker', :type => :class do
       :operatingsystem => 'RedHat',
       :operatingsystemrelease => '6.5',
       :operatingsystemmajrelease => '6',
-      :kernelversion => '2.6.32'
+      :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
     it { should contain_file('/etc/sysconfig/docker').with_content(/DOCKER_NOWARN_KERNEL_VERSION=1/) }
   end
@@ -798,7 +806,8 @@ describe 'docker', :type => :class do
       :operatingsystem => 'RedHat',
       :operatingsystemrelease => '6.5',
       :operatingsystemmajrelease => '6',
-      :kernelversion => '2.6.31'
+      :kernelversion => '2.6.31',
+      :architecture  => 'x86_64',
     } }
     it { should_not contain_file('/etc/sysconfig/docker').with_content(/DOCKER_NOWARN_KERNEL_VERSION=1/) }
   end
@@ -809,10 +818,11 @@ describe 'docker', :type => :class do
       :operatingsystem => 'Family',
       :operatingsystemrelease => '21.0',
       :operatingsystemmajrelease => '21',
-      :kernelversion => '2.6.31'
+      :kernelversion => '2.6.31',
+      :architecture  => 'x86_64',
     } }
 
-    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_package('docker').with_name('docker-ce') }
     it { should contain_yumrepo('docker').with_descr('Docker') }
     it { should_not contain_class('epel') }
   end
@@ -825,6 +835,7 @@ describe 'docker', :type => :class do
         :operatingsystemrelease => '7.0',
         :operatingsystemmajrelease => '7',
         :kernelversion => '2.6.32',
+        :architecture  => 'x86_64',
       } }
 
       storage_setup_file = '/etc/sysconfig/docker-storage-setup'
@@ -899,9 +910,10 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '7.0',
       :operatingsystemmajrelease => '7',
       :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
 
-    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_package('docker').with_name('docker-ce') }
     it { should contain_yumrepo('docker') }
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=rhel7-extras') }
@@ -920,9 +932,10 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '7.0',
       :operatingsystemmajrelease => '7',
       :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
 
-    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_package('docker').with_name('docker-ce') }
     it { should_not contain_class('epel') }
     it { should contain_package('docker').with_install_options('--enablerepo=ol7_addons') }
   end
@@ -934,9 +947,10 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '7.0',
       :operatingsystemmajrelease => '7',
       :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
 
-    it { should contain_package('docker').with_name('docker-engine') }
+    it { should contain_package('docker').with_name('docker-ce') }
     it { should_not contain_class('epel') }
   end
 
@@ -965,7 +979,7 @@ describe 'docker', :type => :class do
       :kernelrelease          => '3.8.0-29-generic'
     } }
     it { should contain_service('docker').with_provider('upstart') }
-    it { should contain_package('docker').with_name('docker-engine').with_ensure('present')  }
+    it { should contain_package('docker').with_name('docker-ce').with_ensure('present')  }
     it { should contain_package('apparmor') }
   end
 
@@ -1005,6 +1019,7 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '6.4',
       :operatingsystemmajrelease => '6',
       :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
     it do
       expect {
@@ -1020,6 +1035,7 @@ describe 'docker', :type => :class do
       :operatingsystemrelease => '2015.09',
       :operatingsystemmajrelease => '2015',
       :kernelversion => '2.6.32',
+      :architecture  => 'x86_64',
     } }
     it {should contain_service('docker').without_provider }
   end

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -90,7 +90,7 @@ require 'spec_helper'
           else
             it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo/) }
             it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-bar/) }
-            it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo_bar-baz/) }            
+            it { should contain_file(initscript).with_content(/Required-Start:.*\s+docker-foo_bar-baz/) }
           end
         end
       end
@@ -706,6 +706,7 @@ require 'spec_helper'
         it { should compile.with_all_deps }
         it { should contain_service('docker-sample').with_ensure(false) }
         it { should contain_exec("remove container docker-sample").with_command('docker rm -v sample') }
+        it { should contain_file(initscript).with_ensure('absent') }
       end
 
     end

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-debian.conf.erb
@@ -2,5 +2,5 @@
 EnvironmentFile=-/etc/default/docker
 EnvironmentFile=-/etc/default/docker-storage
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_daemon_command %> $OPTIONS \
         $DOCKER_STORAGE_OPTIONS

--- a/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
+++ b/templates/etc/systemd/system/docker.service.d/service-overrides-rhel.conf.erb
@@ -5,7 +5,7 @@ EnvironmentFile=-/etc/sysconfig/docker-network
 <% if @daemon_environment_files %><% @daemon_environment_files.each do |param| %>EnvironmentFile=-<%= param %>
 <% end %><% end -%>
 ExecStart=
-ExecStart=/usr/bin/<%= @docker_command %> <%= @daemon_subcommand %> $OPTIONS \
+ExecStart=/usr/bin/<%= @docker_daemon_command %> $OPTIONS \
       $DOCKER_STORAGE_OPTIONS \
       $DOCKER_NETWORK_OPTIONS \
       $BLOCK_REGISTRY \


### PR DESCRIPTION
This pull request adds the following changes:
- Add support for public docker-ce repos (stable, edge, and test) for Debian, Ubuntu, Fedora and CentOS.
- Add support for docker-ee with non-public repositories
- Purge old conflicting packages (docker.io, docker-engine, etc)
- Fix new docker daemon binary name. 

Tests has been added/updated for changed functionality. 