### PR TITLE
Enabling overlay2 storage driver support on RHEL/CentOS for Docker EE/CE

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,6 +279,11 @@
 #   synchronization, to continue even though the configuration may be buggy.
 #   Defaults to true
 #
+# [*dm_override_overlay2_kernel_check*]
+#   Allows to enable overlay2 storage driver on RHEL/CentOS using Docker EE/CE.
+#   Do not attempt to use overlay2 with kernel versions older than 3.10.0-693.
+#   Defaults to false
+#
 # [*manage_package*]
 #   Won't install or define the docker package, useful if you want to use your own package
 #   Defaults to true
@@ -408,6 +413,7 @@ class docker(
   $dm_use_deferred_deletion          = $docker::params::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::params::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::params::dm_override_udev_sync_check,
+  $overlay2_override_kernel_check    = $docker::params::overlay2_override_kernel_check,
   $execdriver                        = $docker::params::execdriver,
   $manage_package                    = $docker::params::manage_package,
   $package_source                    = $docker::params::package_source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,7 @@ class docker::params {
   $dm_use_deferred_deletion          = undef
   $dm_blkdiscard                     = undef
   $dm_override_udev_sync_check       = undef
+  $overlay2_override_kernel_check    = undef
   $manage_package                    = true
   $package_source                    = undef
   $manage_kernel                     = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -85,6 +85,7 @@ class docker::service (
   $dm_use_deferred_deletion          = $docker::dm_use_deferred_deletion,
   $dm_blkdiscard                     = $docker::dm_blkdiscard,
   $dm_override_udev_sync_check       = $docker::dm_override_udev_sync_check,
+  $overlay2_override_kernel_check    = $docker::overlay2_override_kernel_check,
   $storage_devs                      = $docker::storage_devs,
   $storage_vg                        = $docker::storage_vg,
   $storage_root_size                 = $docker::storage_root_size,

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -515,6 +515,15 @@ describe 'docker', :type => :class do
         it { should contain_file(storage_config_file).with_content(/--storage-opt dm\.override_udev_sync_check=true/) }
       end
 
+      context 'with overlay2 override kernel check param' do
+        let(:params) {
+          { 'storage_driver' => 'overlay2',
+            'overlay2_override_kernel_check' => 'true'
+          }
+        }
+        it { should contain_file(storage_config_file).with_content(/--storage-opt overlay2\.override_kernel_check=true/) }
+      end
+
       context 'without execdriver param' do
         it { should_not contain_file(service_config_file).with_content(/-e lxc/) }
         it { should_not contain_file(service_config_file).with_content(/-e native/) }

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -42,6 +42,9 @@ other_args="<% -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>
+<% if @storage_driver == 'overlay2' -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
+<% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 "

--- a/templates/etc/conf.d/docker.gentoo.erb
+++ b/templates/etc/conf.d/docker.gentoo.erb
@@ -42,6 +42,9 @@ DOCKER_OPTS="<% -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>
+<% if @storage_driver == 'overlay2' -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
+<% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 "

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -59,6 +59,9 @@ DOCKER_OPTS="\
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>
+<% if @storage_driver == 'overlay2' -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
+<% end -%>
 <% @labels.each do |label| %> --label <%= label %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 "

--- a/templates/etc/sysconfig/docker-storage.erb
+++ b/templates/etc/sysconfig/docker-storage.erb
@@ -34,4 +34,7 @@ DOCKER_STORAGE_OPTIONS="<% -%>
 <% if @dm_blkdiscard %> --storage-opt dm.blkdiscard=<%= @dm_blkdiscard %><% end -%>
 <% if @dm_override_udev_sync_check %> --storage-opt dm.override_udev_sync_check=<%= @dm_override_udev_sync_check %><% end -%>
 <% end -%>
+<% if @storage_driver == 'overlay2' -%>
+<% if @overlay2_override_kernel_check %> --storage-opt overlay2.override_kernel_check=<%= @overlay2_override_kernel_check %><% end -%>
+<% end -%>
 "


### PR DESCRIPTION
This change allows to enable overlay2 storage driver on RHEL/CentOS operating systems for Docker EE/CE.