### PR TITLE
Check if login was triggered already

### DIFF
--- a/manifests/registry.pp
+++ b/manifests/registry.pp
@@ -67,6 +67,7 @@ define docker::registry(
     cwd         => '/root',
     path        => ['/bin', '/usr/bin'],
     timeout     => 0,
+    unless      => "grep -q \"${title}\" ~/.docker/config.json",
   }
 
 }


### PR DESCRIPTION
I suppose login should not happen upon every puppet run for a given registry