### PR TITLE
Allow overriding service_provider on docker::run

### DIFF
--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -145,6 +145,13 @@ require 'spec_helper'
         end
       end
 
+      context 'when passing `service_provider`' do
+        context 'when forcing use of systemd' do
+          let(:params) { {'command' => 'command', 'image' => 'base', 'service_provider' => 'systemd'} }
+          it { should contain_file('/etc/systemd/system/docker-sample.service') }
+        end
+      end
+
       context 'removing containers and volumes' do
         context 'when trying to remove the volume and not the container on stop' do
           let(:params) {{


### PR DESCRIPTION
Its possible to override the `service_provider` when managing the docker
daemon in case the defaults in params.pp aren't correct, but not when
defining a container using `docker::run`. This change adds a new
`service_provider` parameter to the run defined type, so that containers
can also be managed in these situations.

Fixes garethr/garethr-docker#755